### PR TITLE
refactor: remove redundant sanitize_for_api wrapper

### DIFF
--- a/src/utils/sanitize.rs
+++ b/src/utils/sanitize.rs
@@ -46,9 +46,7 @@ pub fn sanitize_surrogates(s: &str) -> String {
 /// let sanitized = sanitize_for_api("Hello, world!");
 /// assert_eq!(sanitized, "Hello, world!");
 /// ```
-pub fn sanitize_for_api(s: &str) -> String {
-    sanitize_surrogates(s)
-}
+pub use sanitize_surrogates as sanitize_for_api;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
### Motivation
- Reduce indirection and delete a tiny redundant wrapper to simplify the public sanitize API while preserving behavior.

### Description
- Replace the dedicated `sanitize_for_api` function with a re-export alias `pub use sanitize_surrogates as sanitize_for_api;` in `src/utils/sanitize.rs`, removing the extra wrapper.

### Testing
- Ran `cargo fmt --all`, `cargo check`, `cargo clippy --all-targets --all-features`, `cargo test` (unit tests: 80 passed), and `make complexity` (no violations); `make duplicates` could not run because `polydup-cli` is not installed in this environment (network install failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fdca445208325b1388dc3485c43f9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal function declarations to improve code maintainability and reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->