### PR TITLE
MiniMax first-class provider/API + live smoke scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ async fn main() -> alchemy_llm::Result<()> {
 | `api_lifecycle` | Full API lifecycle demonstration |
 | `simple_chat` | Basic chat with GPT-4o-mini |
 | `tool_calling` | Tool/function calling with weather API |
+| `minimax_live_reasoning_split` | Live MiniMax stream with `reasoning_split` enabled |
+| `minimax_live_inline_think` | Live MiniMax stream exercising `<think>` fallback parsing |
+| `minimax_live_usage_chunk` | Live MiniMax final message + usage summary |
 
 ## Development
 

--- a/examples/minimax_live_inline_think.rs
+++ b/examples/minimax_live_inline_think.rs
@@ -1,0 +1,67 @@
+use alchemy_llm::stream;
+use alchemy_llm::types::{AssistantMessageEvent, Context, Message, UserContent, UserMessage};
+use alchemy_llm::{minimax_m2_5, OpenAICompletionsOptions};
+use futures::StreamExt;
+
+fn prompt_from_env() -> String {
+    std::env::var("MINIMAX_INLINE_PROMPT").unwrap_or_else(|_| {
+        "Think step by step, then give only the final numeric answer to: 1729 + 98".to_string()
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("MINIMAX_API_KEY").map_err(|_| "MINIMAX_API_KEY not set")?;
+    let prompt = prompt_from_env();
+
+    let mut model = minimax_m2_5();
+    model.reasoning = false;
+
+    let context = Context {
+        system_prompt: Some("You are a precise math assistant.".to_string()),
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text(prompt),
+            timestamp: 0,
+        })],
+        tools: None,
+    };
+
+    let options = Some(OpenAICompletionsOptions {
+        api_key: Some(api_key),
+        temperature: Some(0.3),
+        max_tokens: Some(512),
+        ..OpenAICompletionsOptions::default()
+    });
+
+    let mut event_stream = stream(&model, &context, options)?;
+
+    println!("== MiniMax inline <think> fallback stream ==");
+
+    while let Some(event) = event_stream.next().await {
+        match event {
+            AssistantMessageEvent::ThinkingStart { .. } => println!("\n[thinking:start]"),
+            AssistantMessageEvent::ThinkingDelta { delta, .. } => print!("{delta}"),
+            AssistantMessageEvent::ThinkingEnd { .. } => println!("\n[thinking:end]"),
+            AssistantMessageEvent::TextStart { .. } => println!("\n[text:start]"),
+            AssistantMessageEvent::TextDelta { delta, .. } => print!("{delta}"),
+            AssistantMessageEvent::TextEnd { .. } => println!("\n[text:end]"),
+            AssistantMessageEvent::Done { message, .. } => {
+                println!("\n== done ==");
+                println!("stop_reason: {:?}", message.stop_reason);
+                println!(
+                    "usage: input={} output={} total={}",
+                    message.usage.input, message.usage.output, message.usage.total_tokens
+                );
+                break;
+            }
+            AssistantMessageEvent::Error { error, .. } => {
+                eprintln!("\n== error ==");
+                eprintln!("{:?}", error.error_message);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/examples/minimax_live_reasoning_split.rs
+++ b/examples/minimax_live_reasoning_split.rs
@@ -1,0 +1,70 @@
+use alchemy_llm::stream;
+use alchemy_llm::types::{AssistantMessageEvent, Context, Message, UserContent, UserMessage};
+use alchemy_llm::{minimax_m2_5, OpenAICompletionsOptions};
+use futures::StreamExt;
+
+fn prompt_from_env() -> String {
+    std::env::var("MINIMAX_PROMPT").unwrap_or_else(|_| {
+        "Explain why Rust ownership prevents data races in one paragraph.".to_string()
+    })
+}
+
+fn api_key_from_env() -> Result<String, std::env::VarError> {
+    std::env::var("MINIMAX_API_KEY")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = api_key_from_env().map_err(|_| "MINIMAX_API_KEY not set")?;
+    let prompt = prompt_from_env();
+
+    let model = minimax_m2_5();
+    let context = Context {
+        system_prompt: Some("You are a concise technical assistant.".to_string()),
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text(prompt),
+            timestamp: 0,
+        })],
+        tools: None,
+    };
+
+    let options = Some(OpenAICompletionsOptions {
+        api_key: Some(api_key),
+        temperature: Some(0.7),
+        max_tokens: Some(768),
+        ..OpenAICompletionsOptions::default()
+    });
+
+    let mut event_stream = stream(&model, &context, options)?;
+
+    println!("== MiniMax reasoning_split stream ==");
+
+    while let Some(event) = event_stream.next().await {
+        match event {
+            AssistantMessageEvent::ThinkingStart { .. } => println!("\n[thinking:start]"),
+            AssistantMessageEvent::ThinkingDelta { delta, .. } => print!("{delta}"),
+            AssistantMessageEvent::ThinkingEnd { .. } => println!("\n[thinking:end]"),
+            AssistantMessageEvent::TextStart { .. } => println!("\n[text:start]"),
+            AssistantMessageEvent::TextDelta { delta, .. } => print!("{delta}"),
+            AssistantMessageEvent::TextEnd { .. } => println!("\n[text:end]"),
+            AssistantMessageEvent::Done { message, .. } => {
+                println!("\n== done ==");
+                println!("model: {}", message.model);
+                println!("stop_reason: {:?}", message.stop_reason);
+                println!(
+                    "usage: input={} output={} total={}",
+                    message.usage.input, message.usage.output, message.usage.total_tokens
+                );
+                break;
+            }
+            AssistantMessageEvent::Error { error, .. } => {
+                eprintln!("\n== error ==");
+                eprintln!("{:?}", error.error_message);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/examples/minimax_live_usage_chunk.rs
+++ b/examples/minimax_live_usage_chunk.rs
@@ -1,0 +1,69 @@
+use alchemy_llm::stream;
+use alchemy_llm::types::{Content, Context, Message, UserContent, UserMessage};
+use alchemy_llm::{minimax_m2_5, OpenAICompletionsOptions};
+
+fn default_prompt() -> String {
+    std::env::var("MINIMAX_USAGE_PROMPT").unwrap_or_else(|_| "Reply with exactly: OK".to_string())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("MINIMAX_API_KEY").map_err(|_| "MINIMAX_API_KEY not set")?;
+
+    let mut model = minimax_m2_5();
+    model.reasoning = false;
+    let context = Context {
+        system_prompt: Some("You are terse.".to_string()),
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text(default_prompt()),
+            timestamp: 0,
+        })],
+        tools: None,
+    };
+
+    let options = Some(OpenAICompletionsOptions {
+        api_key: Some(api_key),
+        temperature: Some(0.8),
+        max_tokens: Some(1024),
+        ..OpenAICompletionsOptions::default()
+    });
+
+    let message = stream(&model, &context, options)?.result().await?;
+
+    println!("== MiniMax final message ==");
+    println!("api: {:?}", message.api);
+    println!("provider: {:?}", message.provider);
+    println!("model: {}", message.model);
+    println!("stop_reason: {:?}", message.stop_reason);
+
+    println!("\ncontent blocks:");
+    for (index, block) in message.content.iter().enumerate() {
+        match block {
+            Content::Thinking { inner } => {
+                println!(
+                    "  [{index}] thinking len={} sig={:?}",
+                    inner.thinking.len(),
+                    inner.thinking_signature
+                );
+            }
+            Content::Text { inner } => {
+                println!("  [{index}] text: {}", inner.text);
+            }
+            Content::ToolCall { inner } => {
+                println!("  [{index}] tool_call: {} {}", inner.id, inner.name);
+            }
+            Content::Image { inner } => {
+                println!("  [{index}] image bytes={}", inner.data.len());
+            }
+        }
+    }
+
+    println!("\nusage:");
+    println!("  input={}", message.usage.input);
+    println!("  output={}", message.usage.output);
+    println!("  cache_read={}", message.usage.cache_read);
+    println!("  cache_write={}", message.usage.cache_write);
+    println!("  total={}", message.usage.total_tokens);
+
+    Ok(())
+}

--- a/smokescripts/README.md
+++ b/smokescripts/README.md
@@ -1,0 +1,36 @@
+# MiniMax Smoke Scripts
+
+Live smoke scripts for the first-class MiniMax provider.
+
+## Prerequisites
+
+- `MINIMAX_API_KEY` must be set (or present in `.env` at repo root).
+- Internet access to `https://api.minimax.io`.
+
+## Scripts
+
+- `smokescripts/run_minimax_reasoning_split.sh`  
+  Runs `examples/minimax_live_reasoning_split.rs`.
+- `smokescripts/run_minimax_inline_think.sh`  
+  Runs `examples/minimax_live_inline_think.rs`.
+- `smokescripts/run_minimax_usage_chunk.sh`  
+  Runs `examples/minimax_live_usage_chunk.rs`.
+- `smokescripts/run_all_minimax.sh`  
+  Runs all three smoke examples in sequence.
+
+## Usage
+
+```bash
+bash smokescripts/run_minimax_reasoning_split.sh
+bash smokescripts/run_minimax_inline_think.sh
+bash smokescripts/run_minimax_usage_chunk.sh
+bash smokescripts/run_all_minimax.sh
+```
+
+### Optional prompt overrides
+
+```bash
+MINIMAX_PROMPT="Explain borrow checker in 4 bullets" bash smokescripts/run_minimax_reasoning_split.sh
+MINIMAX_INLINE_PROMPT="Think step by step then answer: 21*19" bash smokescripts/run_minimax_inline_think.sh
+MINIMAX_USAGE_PROMPT="Summarize Rust async in one stanza" bash smokescripts/run_minimax_usage_chunk.sh
+```

--- a/smokescripts/run_all_minimax.sh
+++ b/smokescripts/run_all_minimax.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "${SCRIPT_DIR}/run_minimax_reasoning_split.sh"
+echo
+echo "----------------------------------------"
+echo
+bash "${SCRIPT_DIR}/run_minimax_inline_think.sh"
+echo
+echo "----------------------------------------"
+echo
+bash "${SCRIPT_DIR}/run_minimax_usage_chunk.sh"

--- a/smokescripts/run_minimax_inline_think.sh
+++ b/smokescripts/run_minimax_inline_think.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/.env"
+  set +a
+fi
+
+: "${MINIMAX_API_KEY:?MINIMAX_API_KEY is required}"
+
+export MINIMAX_INLINE_PROMPT="${MINIMAX_INLINE_PROMPT:-${1:-Think step by step, then answer: 1729 + 98}}"
+
+cd "${REPO_ROOT}"
+cargo run --example minimax_live_inline_think

--- a/smokescripts/run_minimax_reasoning_split.sh
+++ b/smokescripts/run_minimax_reasoning_split.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/.env"
+  set +a
+fi
+
+: "${MINIMAX_API_KEY:?MINIMAX_API_KEY is required}"
+
+export MINIMAX_PROMPT="${MINIMAX_PROMPT:-${1:-Explain Rust lifetimes with one concrete example.}}"
+
+cd "${REPO_ROOT}"
+cargo run --example minimax_live_reasoning_split

--- a/smokescripts/run_minimax_usage_chunk.sh
+++ b/smokescripts/run_minimax_usage_chunk.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/.env"
+  set +a
+fi
+
+: "${MINIMAX_API_KEY:?MINIMAX_API_KEY is required}"
+
+export MINIMAX_USAGE_PROMPT="${MINIMAX_USAGE_PROMPT:-${1:-Write a short haiku about async Rust.}}"
+
+cd "${REPO_ROOT}"
+cargo run --example minimax_live_usage_chunk

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod models;
 pub mod providers;
 pub mod stream;
 pub mod transform;
@@ -6,10 +7,19 @@ pub mod types;
 pub mod utils;
 
 pub use error::{Error, Result};
-pub use providers::{get_env_api_key, stream_openai_completions, OpenAICompletionsOptions};
+pub use models::{
+    minimax_cn_m2, minimax_cn_m2_1, minimax_cn_m2_1_highspeed, minimax_cn_m2_5,
+    minimax_cn_m2_5_highspeed, minimax_m2, minimax_m2_1, minimax_m2_1_highspeed, minimax_m2_5,
+    minimax_m2_5_highspeed,
+};
+pub use providers::{
+    get_env_api_key, stream_minimax_completions, stream_openai_completions,
+    OpenAICompletionsOptions,
+};
 pub use stream::{complete, stream, AssistantMessageEventStream};
 pub use transform::{transform_messages, transform_messages_simple, TargetModel};
 pub use utils::{
     is_context_overflow, parse_streaming_json, parse_streaming_json_smart, sanitize_for_api,
-    sanitize_surrogates, validate_tool_arguments, validate_tool_call,
+    sanitize_surrogates, validate_tool_arguments, validate_tool_call, ThinkFragment,
+    ThinkTagParser,
 };

--- a/src/models/minimax.rs
+++ b/src/models/minimax.rs
@@ -1,0 +1,146 @@
+use crate::types::{InputType, KnownProvider, MinimaxCompletions, Model, ModelCost, Provider};
+
+const MINIMAX_GLOBAL_BASE_URL: &str = "https://api.minimax.io/v1/chat/completions";
+const MINIMAX_CN_BASE_URL: &str = "https://api.minimax.chat/v1/chat/completions";
+const MINIMAX_CONTEXT_WINDOW: u32 = 204_800;
+const MINIMAX_MAX_OUTPUT_TOKENS: u32 = 16_384;
+const ZERO_MODEL_COST: ModelCost = ModelCost {
+    input: 0.0,
+    output: 0.0,
+    cache_read: 0.0,
+    cache_write: 0.0,
+};
+
+fn build_minimax_model(
+    id: &str,
+    name: &str,
+    provider: KnownProvider,
+    base_url: &str,
+) -> Model<MinimaxCompletions> {
+    Model {
+        id: id.to_string(),
+        name: name.to_string(),
+        api: MinimaxCompletions,
+        provider: Provider::Known(provider),
+        base_url: base_url.to_string(),
+        reasoning: true,
+        input: vec![InputType::Text],
+        cost: ZERO_MODEL_COST,
+        context_window: MINIMAX_CONTEXT_WINDOW,
+        max_tokens: MINIMAX_MAX_OUTPUT_TOKENS,
+        headers: None,
+        compat: None,
+    }
+}
+
+pub fn minimax_m2_5() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.5",
+        "MiniMax M2.5",
+        KnownProvider::Minimax,
+        MINIMAX_GLOBAL_BASE_URL,
+    )
+}
+
+pub fn minimax_m2_5_highspeed() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.5-highspeed",
+        "MiniMax M2.5 Highspeed",
+        KnownProvider::Minimax,
+        MINIMAX_GLOBAL_BASE_URL,
+    )
+}
+
+pub fn minimax_m2_1() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.1",
+        "MiniMax M2.1",
+        KnownProvider::Minimax,
+        MINIMAX_GLOBAL_BASE_URL,
+    )
+}
+
+pub fn minimax_m2_1_highspeed() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.1-highspeed",
+        "MiniMax M2.1 Highspeed",
+        KnownProvider::Minimax,
+        MINIMAX_GLOBAL_BASE_URL,
+    )
+}
+
+pub fn minimax_m2() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2",
+        "MiniMax M2",
+        KnownProvider::Minimax,
+        MINIMAX_GLOBAL_BASE_URL,
+    )
+}
+
+pub fn minimax_cn_m2_5() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.5",
+        "MiniMax M2.5 (CN)",
+        KnownProvider::MinimaxCn,
+        MINIMAX_CN_BASE_URL,
+    )
+}
+
+pub fn minimax_cn_m2_5_highspeed() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.5-highspeed",
+        "MiniMax M2.5 Highspeed (CN)",
+        KnownProvider::MinimaxCn,
+        MINIMAX_CN_BASE_URL,
+    )
+}
+
+pub fn minimax_cn_m2_1() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.1",
+        "MiniMax M2.1 (CN)",
+        KnownProvider::MinimaxCn,
+        MINIMAX_CN_BASE_URL,
+    )
+}
+
+pub fn minimax_cn_m2_1_highspeed() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2.1-highspeed",
+        "MiniMax M2.1 Highspeed (CN)",
+        KnownProvider::MinimaxCn,
+        MINIMAX_CN_BASE_URL,
+    )
+}
+
+pub fn minimax_cn_m2() -> Model<MinimaxCompletions> {
+    build_minimax_model(
+        "MiniMax-M2",
+        "MiniMax M2 (CN)",
+        KnownProvider::MinimaxCn,
+        MINIMAX_CN_BASE_URL,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Api, ApiType};
+
+    #[test]
+    fn minimax_model_has_first_class_api() {
+        let model = minimax_m2_5();
+        assert_eq!(model.api.api(), Api::MinimaxCompletions);
+        assert_eq!(model.provider, Provider::Known(KnownProvider::Minimax));
+        assert_eq!(model.base_url, MINIMAX_GLOBAL_BASE_URL);
+    }
+
+    #[test]
+    fn minimax_cn_model_uses_cn_provider_and_url() {
+        let model = minimax_cn_m2_1_highspeed();
+        assert_eq!(model.api.api(), Api::MinimaxCompletions);
+        assert_eq!(model.provider, Provider::Known(KnownProvider::MinimaxCn));
+        assert_eq!(model.base_url, MINIMAX_CN_BASE_URL);
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,7 @@
+pub mod minimax;
+
+pub use minimax::{
+    minimax_cn_m2, minimax_cn_m2_1, minimax_cn_m2_1_highspeed, minimax_cn_m2_5,
+    minimax_cn_m2_5_highspeed, minimax_m2, minimax_m2_1, minimax_m2_1_highspeed, minimax_m2_5,
+    minimax_m2_5_highspeed,
+};

--- a/src/providers/minimax.rs
+++ b/src/providers/minimax.rs
@@ -1,0 +1,618 @@
+use serde::Deserialize;
+use serde_json::json;
+
+use super::openai_completions::OpenAICompletionsOptions;
+use super::shared::{
+    build_http_client, convert_messages, convert_tools, finish_current_block,
+    handle_reasoning_delta, handle_text_delta, handle_tool_calls, initialize_output,
+    map_stop_reason, process_sse_stream, push_stream_done, push_stream_error,
+    send_streaming_request, update_usage_from_chunk, CurrentBlock, OpenAiLikeMessageOptions,
+    OpenAiLikeStreamUsage, OpenAiLikeToolCallDelta, ReasoningDelta, SystemPromptRole,
+};
+use crate::stream::{AssistantMessageEventStream, EventStreamSender};
+use crate::types::{
+    Api, AssistantMessage, AssistantMessageEvent, Context, MinimaxCompletions, Model,
+};
+use crate::utils::{ThinkFragment, ThinkTagParser};
+
+const STREAM_INCLUDE_USAGE_FIELD: &str = "include_usage";
+const MAX_TOKENS_FIELD: &str = "max_tokens";
+const REASONING_SPLIT_FIELD: &str = "reasoning_split";
+const REASONING_DETAILS_SIGNATURE: &str = "reasoning_details";
+const REASONING_CONTENT_SIGNATURE: &str = "reasoning_content";
+const REASONING_SIGNATURE: &str = "reasoning";
+const REASONING_TEXT_SIGNATURE: &str = "reasoning_text";
+const THINK_TAG_SIGNATURE: &str = "think_tag";
+
+/// Stream completions from MiniMax chat/completions API.
+pub fn stream_minimax_completions(
+    model: &Model<MinimaxCompletions>,
+    context: &Context,
+    options: OpenAICompletionsOptions,
+) -> AssistantMessageEventStream {
+    let (stream, sender) = AssistantMessageEventStream::new();
+
+    let model = model.clone();
+    let context = context.clone();
+
+    tokio::spawn(async move {
+        run_stream(model, context, options, sender).await;
+    });
+
+    stream
+}
+
+async fn run_stream(
+    model: Model<MinimaxCompletions>,
+    context: Context,
+    options: OpenAICompletionsOptions,
+    mut sender: EventStreamSender,
+) {
+    let mut output = initialize_output(
+        Api::MinimaxCompletions,
+        model.provider.clone(),
+        model.id.clone(),
+    );
+
+    if let Err(error) = run_stream_inner(&model, &context, &options, &mut output, &mut sender).await
+    {
+        push_stream_error(&mut output, &mut sender, error);
+    }
+}
+
+async fn run_stream_inner(
+    model: &Model<MinimaxCompletions>,
+    context: &Context,
+    options: &OpenAICompletionsOptions,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+) -> Result<(), crate::Error> {
+    let api_key = options
+        .api_key
+        .as_ref()
+        .ok_or_else(|| crate::Error::NoApiKey(model.provider.to_string()))?;
+
+    let client = build_http_client(api_key, model.headers.as_ref(), options.headers.as_ref())?;
+    let params = build_params(model, context, options);
+
+    let response = send_streaming_request(&client, &model.base_url, &params).await?;
+
+    sender.push(AssistantMessageEvent::Start {
+        partial: output.clone(),
+    });
+
+    let mut current_block: Option<CurrentBlock> = None;
+    let mut think_tag_parser = ThinkTagParser::new();
+
+    process_sse_stream::<StreamChunk, _>(response, |chunk| {
+        process_chunk(
+            &chunk,
+            output,
+            sender,
+            &mut current_block,
+            &mut think_tag_parser,
+        );
+    })
+    .await?;
+
+    flush_think_tag_parser(&mut think_tag_parser, output, sender, &mut current_block);
+    finish_current_block(&mut current_block, output, sender);
+    push_stream_done(output, sender);
+
+    Ok(())
+}
+
+fn build_params(
+    model: &Model<MinimaxCompletions>,
+    context: &Context,
+    options: &OpenAICompletionsOptions,
+) -> serde_json::Value {
+    let message_options = OpenAiLikeMessageOptions {
+        system_role: SystemPromptRole::System,
+        requires_tool_result_name: false,
+    };
+
+    let mut params = json!({
+        "model": model.id,
+        "stream": true,
+        "messages": convert_messages(model, context, &message_options),
+    });
+
+    let mut stream_options = serde_json::Map::new();
+    stream_options.insert(STREAM_INCLUDE_USAGE_FIELD.to_string(), json!(true));
+    params["stream_options"] = serde_json::Value::Object(stream_options);
+
+    if model.reasoning {
+        params[REASONING_SPLIT_FIELD] = json!(true);
+    }
+
+    if let Some(max_tokens) = options.max_tokens {
+        params[MAX_TOKENS_FIELD] = json!(max_tokens);
+    }
+
+    if let Some(temperature) = options.temperature {
+        params["temperature"] = json!(temperature);
+    }
+
+    if let Some(tools) = &context.tools {
+        params["tools"] = convert_tools(tools);
+    }
+
+    if let Some(tool_choice) = &options.tool_choice {
+        params["tool_choice"] = serde_json::to_value(tool_choice).unwrap_or(json!("auto"));
+    }
+
+    params
+}
+
+fn process_chunk(
+    chunk: &StreamChunk,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+    think_tag_parser: &mut ThinkTagParser,
+) {
+    if let Some(usage) = &chunk.usage {
+        update_usage_from_chunk(usage, output);
+    }
+
+    let Some(choice) = chunk.choices.first() else {
+        return;
+    };
+
+    if let Some(reason) = &choice.finish_reason {
+        output.stop_reason = map_stop_reason(reason);
+    }
+
+    let Some(delta) = &choice.delta else {
+        return;
+    };
+
+    let explicit_reasoning = emit_explicit_reasoning(delta, output, sender, current_block);
+
+    if let Some(content) = delta.content.as_deref() {
+        if explicit_reasoning {
+            handle_text_delta(content, output, sender, current_block);
+        } else {
+            process_content_with_fallback(content, think_tag_parser, output, sender, current_block);
+        }
+    }
+
+    if let Some(tool_calls) = &delta.tool_calls {
+        handle_tool_calls(tool_calls, output, sender, current_block);
+    }
+}
+
+fn emit_explicit_reasoning(
+    delta: &StreamDelta,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) -> bool {
+    let mut emitted_reasoning = false;
+
+    if let Some(details) = &delta.reasoning_details {
+        for detail in details {
+            if let Some(text) = detail.text.as_deref() {
+                if text.is_empty() {
+                    continue;
+                }
+
+                emitted_reasoning = true;
+                handle_reasoning_delta(
+                    ReasoningDelta {
+                        text,
+                        signature: REASONING_DETAILS_SIGNATURE,
+                    },
+                    output,
+                    sender,
+                    current_block,
+                );
+            }
+        }
+    }
+
+    if emitted_reasoning {
+        return true;
+    }
+
+    for (text, signature) in [
+        (
+            delta.reasoning_content.as_deref(),
+            REASONING_CONTENT_SIGNATURE,
+        ),
+        (delta.reasoning.as_deref(), REASONING_SIGNATURE),
+        (delta.reasoning_text.as_deref(), REASONING_TEXT_SIGNATURE),
+    ] {
+        if let Some(reasoning_text) = text {
+            if reasoning_text.is_empty() {
+                continue;
+            }
+
+            handle_reasoning_delta(
+                ReasoningDelta {
+                    text: reasoning_text,
+                    signature,
+                },
+                output,
+                sender,
+                current_block,
+            );
+            return true;
+        }
+    }
+
+    false
+}
+
+fn process_content_with_fallback(
+    content: &str,
+    think_tag_parser: &mut ThinkTagParser,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    for fragment in think_tag_parser.feed(content) {
+        match fragment {
+            ThinkFragment::Text(text) => {
+                handle_text_delta(&text, output, sender, current_block);
+            }
+            ThinkFragment::Thinking(thinking) => {
+                handle_reasoning_delta(
+                    ReasoningDelta {
+                        text: &thinking,
+                        signature: THINK_TAG_SIGNATURE,
+                    },
+                    output,
+                    sender,
+                    current_block,
+                );
+            }
+        }
+    }
+}
+
+fn flush_think_tag_parser(
+    think_tag_parser: &mut ThinkTagParser,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    for fragment in think_tag_parser.flush() {
+        match fragment {
+            ThinkFragment::Text(text) => {
+                handle_text_delta(&text, output, sender, current_block);
+            }
+            ThinkFragment::Thinking(thinking) => {
+                handle_reasoning_delta(
+                    ReasoningDelta {
+                        text: &thinking,
+                        signature: THINK_TAG_SIGNATURE,
+                    },
+                    output,
+                    sender,
+                    current_block,
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamChunk {
+    #[serde(default)]
+    choices: Vec<StreamChoice>,
+    usage: Option<OpenAiLikeStreamUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamChoice {
+    delta: Option<StreamDelta>,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamDelta {
+    content: Option<String>,
+    reasoning_details: Option<Vec<ReasoningDetail>>,
+    reasoning_content: Option<String>,
+    reasoning: Option<String>,
+    reasoning_text: Option<String>,
+    tool_calls: Option<Vec<OpenAiLikeToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReasoningDetail {
+    #[serde(rename = "type")]
+    _detail_type: Option<String>,
+    _id: Option<String>,
+    _format: Option<String>,
+    _index: Option<u32>,
+    text: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AssistantMessageEvent, InputType, KnownProvider, ModelCost, Provider, StopReason, Usage,
+        UserContent, UserMessage,
+    };
+    use futures::executor::block_on;
+    use futures::StreamExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    const TEST_BASE_URL: &str = "https://api.minimax.io/v1/chat/completions";
+
+    fn make_model(reasoning: bool) -> Model<MinimaxCompletions> {
+        Model {
+            id: "MiniMax-M2.5".to_string(),
+            name: "MiniMax M2.5".to_string(),
+            api: MinimaxCompletions,
+            provider: Provider::Known(KnownProvider::Minimax),
+            base_url: TEST_BASE_URL.to_string(),
+            reasoning,
+            input: vec![InputType::Text],
+            cost: ModelCost {
+                input: 0.0,
+                output: 0.0,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            },
+            context_window: 204_800,
+            max_tokens: 16_384,
+            headers: None,
+            compat: None,
+        }
+    }
+
+    fn make_context() -> Context {
+        Context {
+            system_prompt: Some("You are concise".to_string()),
+            messages: vec![crate::types::Message::User(UserMessage {
+                content: UserContent::Text("Hello".to_string()),
+                timestamp: 0,
+            })],
+            tools: None,
+        }
+    }
+
+    fn make_output_message() -> AssistantMessage {
+        AssistantMessage {
+            content: vec![],
+            api: Api::MinimaxCompletions,
+            provider: Provider::Known(KnownProvider::Minimax),
+            model: "MiniMax-M2.5".to_string(),
+            usage: Usage::default(),
+            stop_reason: StopReason::Stop,
+            error_message: None,
+            timestamp: 0,
+        }
+    }
+
+    fn process_chunks_for_test(
+        chunks: Vec<StreamChunk>,
+    ) -> (Vec<AssistantMessageEvent>, AssistantMessage) {
+        let (mut stream, mut sender) = AssistantMessageEventStream::new();
+        let mut output = make_output_message();
+        let mut current_block = None;
+        let mut parser = ThinkTagParser::new();
+
+        for chunk in chunks {
+            process_chunk(
+                &chunk,
+                &mut output,
+                &mut sender,
+                &mut current_block,
+                &mut parser,
+            );
+        }
+
+        flush_think_tag_parser(&mut parser, &mut output, &mut sender, &mut current_block);
+        finish_current_block(&mut current_block, &mut output, &mut sender);
+
+        drop(sender);
+
+        let events = block_on(async move { stream.by_ref().collect::<Vec<_>>().await });
+        (events, output)
+    }
+
+    #[test]
+    fn build_params_for_reasoning_model_uses_minimax_semantics() {
+        let model = make_model(true);
+        let context = make_context();
+        let options = OpenAICompletionsOptions {
+            temperature: Some(1.2),
+            max_tokens: Some(512),
+            ..OpenAICompletionsOptions::default()
+        };
+
+        let params = build_params(&model, &context, &options);
+
+        assert_eq!(params["stream"], true);
+        assert_eq!(params["stream_options"][STREAM_INCLUDE_USAGE_FIELD], true);
+        assert_eq!(params[REASONING_SPLIT_FIELD], true);
+        assert_eq!(params[MAX_TOKENS_FIELD], 512);
+        assert_eq!(params["temperature"], 1.2);
+        assert_eq!(params["messages"][0]["role"], "system");
+        assert_eq!(params["messages"][0]["content"], "You are concise");
+        assert!(params.get("n").is_none());
+        assert!(params.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn build_params_for_non_reasoning_model_omits_reasoning_split() {
+        let model = make_model(false);
+        let context = make_context();
+        let options = OpenAICompletionsOptions::default();
+
+        let params = build_params(&model, &context, &options);
+
+        assert!(params.get(REASONING_SPLIT_FIELD).is_none());
+    }
+
+    #[test]
+    fn process_chunk_maps_reasoning_details_to_thinking_events() {
+        let chunk: StreamChunk = serde_json::from_value(serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "reasoning_details": [
+                        { "type": "reasoning", "id": "r-1", "format": "text", "index": 0, "text": "step one" }
+                    ]
+                }
+            }]
+        }))
+        .expect("valid reasoning details payload");
+
+        let (events, output) = process_chunks_for_test(vec![chunk]);
+
+        assert!(matches!(
+            events[0],
+            AssistantMessageEvent::ThinkingStart { .. }
+        ));
+        assert!(matches!(
+            events[1],
+            AssistantMessageEvent::ThinkingDelta { .. }
+        ));
+        assert!(matches!(
+            events[2],
+            AssistantMessageEvent::ThinkingEnd { .. }
+        ));
+
+        match &output.content[0] {
+            crate::types::Content::Thinking { inner } => {
+                assert_eq!(inner.thinking, "step one");
+                assert_eq!(
+                    inner.thinking_signature.as_deref(),
+                    Some(REASONING_DETAILS_SIGNATURE)
+                );
+            }
+            _ => panic!("expected thinking content"),
+        }
+    }
+
+    #[test]
+    fn process_chunk_with_inline_think_tags_emits_expected_event_order() {
+        let chunk: StreamChunk = serde_json::from_value(serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "content": "<think>reason</think>answer"
+                }
+            }]
+        }))
+        .expect("valid think-tag payload");
+
+        let (events, output) = process_chunks_for_test(vec![chunk]);
+
+        assert!(matches!(
+            events[0],
+            AssistantMessageEvent::ThinkingStart { .. }
+        ));
+        assert!(matches!(
+            events[1],
+            AssistantMessageEvent::ThinkingDelta { .. }
+        ));
+        assert!(matches!(
+            events[2],
+            AssistantMessageEvent::ThinkingEnd { .. }
+        ));
+        assert!(matches!(events[3], AssistantMessageEvent::TextStart { .. }));
+        assert!(matches!(events[4], AssistantMessageEvent::TextDelta { .. }));
+        assert!(matches!(events[5], AssistantMessageEvent::TextEnd { .. }));
+
+        assert_eq!(output.content.len(), 2);
+        match &output.content[0] {
+            crate::types::Content::Thinking { inner } => {
+                assert_eq!(inner.thinking, "reason");
+                assert_eq!(
+                    inner.thinking_signature.as_deref(),
+                    Some(THINK_TAG_SIGNATURE)
+                );
+            }
+            _ => panic!("expected thinking content"),
+        }
+        match &output.content[1] {
+            crate::types::Content::Text { inner } => {
+                assert_eq!(inner.text, "answer");
+            }
+            _ => panic!("expected text content"),
+        }
+    }
+
+    #[test]
+    fn usage_only_chunk_updates_output_usage() {
+        let chunk: StreamChunk = serde_json::from_value(serde_json::json!({
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 12,
+                "completion_tokens": 8,
+                "total_tokens": 20
+            }
+        }))
+        .expect("valid usage-only payload");
+
+        let (_events, output) = process_chunks_for_test(vec![chunk]);
+
+        assert_eq!(output.usage.input, 12);
+        assert_eq!(output.usage.output, 8);
+        assert_eq!(output.usage.total_tokens, 20);
+    }
+
+    async fn spawn_sse_server(body: String) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let address = listener.local_addr().expect("listener address");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+
+            let mut request_buffer = [0_u8; 4096];
+            let _ = socket.read(&mut request_buffer).await;
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        format!("http://{}/v1/chat/completions", address)
+    }
+
+    #[tokio::test]
+    async fn stream_minimax_completions_final_message_shape() {
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"reasoning_details\":[{\"text\":\"reason\"}]}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"answer\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+            "data: [DONE]\n\n"
+        )
+        .to_string();
+
+        let server_url = spawn_sse_server(sse_body).await;
+
+        let mut model = make_model(true);
+        model.base_url = server_url;
+
+        let options = OpenAICompletionsOptions {
+            api_key: Some("test-key".to_string()),
+            ..OpenAICompletionsOptions::default()
+        };
+
+        let stream = stream_minimax_completions(&model, &make_context(), options);
+        let result = stream.result().await.expect("stream result");
+
+        assert_eq!(result.api, Api::MinimaxCompletions);
+        assert_eq!(result.provider, Provider::Known(KnownProvider::Minimax));
+        assert_eq!(result.model, "MiniMax-M2.5");
+        assert_eq!(result.stop_reason, StopReason::Stop);
+        assert_eq!(result.usage.total_tokens, 15);
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,6 +1,8 @@
 pub mod env;
+pub mod minimax;
 pub mod openai_completions;
 pub(crate) mod shared;
 
 pub use env::get_env_api_key;
+pub use minimax::stream_minimax_completions;
 pub use openai_completions::{stream_openai_completions, OpenAICompletionsOptions};

--- a/src/providers/shared/mod.rs
+++ b/src/providers/shared/mod.rs
@@ -1,7 +1,21 @@
 //! Shared utilities for provider implementations.
 
 mod http;
+mod openai_like_messages;
+mod openai_like_runtime;
+mod stream_blocks;
 mod timestamp;
 
 pub(crate) use http::build_http_client;
-pub(crate) use timestamp::unix_timestamp_millis;
+pub(crate) use openai_like_messages::{
+    convert_messages, convert_tools, OpenAiLikeMessageOptions, SystemPromptRole,
+};
+pub(crate) use openai_like_runtime::{
+    initialize_output, process_sse_stream, push_stream_done, push_stream_error,
+    send_streaming_request,
+};
+pub(crate) use stream_blocks::{
+    finish_current_block, handle_reasoning_delta, handle_text_delta, handle_tool_calls,
+    map_stop_reason, update_usage_from_chunk, CurrentBlock, OpenAiLikeStreamUsage,
+    OpenAiLikeToolCallDelta, ReasoningDelta,
+};

--- a/src/providers/shared/openai_like_messages.rs
+++ b/src/providers/shared/openai_like_messages.rs
@@ -1,0 +1,344 @@
+use serde_json::json;
+
+use crate::types::{
+    ApiType, Content, Context, InputType, Message, Model, Tool, ToolResultContent, UserContent,
+    UserContentBlock, UserMessage,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SystemPromptRole {
+    System,
+    Developer,
+}
+
+impl SystemPromptRole {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::Developer => "developer",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OpenAiLikeMessageOptions {
+    pub system_role: SystemPromptRole,
+    pub requires_tool_result_name: bool,
+}
+
+pub(crate) fn convert_messages<TApi: ApiType>(
+    model: &Model<TApi>,
+    context: &Context,
+    options: &OpenAiLikeMessageOptions,
+) -> serde_json::Value {
+    let mut messages = Vec::new();
+
+    push_system_prompt(&mut messages, context, options.system_role);
+
+    for message in &context.messages {
+        match message {
+            Message::User(user) => messages.push(convert_user_message(model, user)),
+            Message::Assistant(assistant) => {
+                if let Some(converted) = convert_assistant_message(assistant) {
+                    messages.push(converted);
+                }
+            }
+            Message::ToolResult(result) => {
+                messages.push(convert_tool_result(
+                    result,
+                    options.requires_tool_result_name,
+                ));
+            }
+        }
+    }
+
+    json!(messages)
+}
+
+fn push_system_prompt(
+    messages: &mut Vec<serde_json::Value>,
+    context: &Context,
+    role: SystemPromptRole,
+) {
+    let Some(system_prompt) = &context.system_prompt else {
+        return;
+    };
+
+    messages.push(json!({
+        "role": role.as_str(),
+        "content": system_prompt,
+    }));
+}
+
+fn convert_user_message<TApi: ApiType>(
+    model: &Model<TApi>,
+    user: &UserMessage,
+) -> serde_json::Value {
+    let content = user_content_to_json(model, &user.content);
+
+    json!({
+        "role": "user",
+        "content": content,
+    })
+}
+
+fn user_content_to_json<TApi: ApiType>(
+    model: &Model<TApi>,
+    content: &UserContent,
+) -> serde_json::Value {
+    match content {
+        UserContent::Text(text) => json!(text),
+        UserContent::Multi(blocks) => {
+            let parts: Vec<serde_json::Value> = blocks
+                .iter()
+                .filter_map(|block| match block {
+                    UserContentBlock::Text(text) => Some(json!({
+                        "type": "text",
+                        "text": text.text,
+                    })),
+                    UserContentBlock::Image(image) if model.input.contains(&InputType::Image) => {
+                        Some(json!({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": format!(
+                                    "data:{};base64,{}",
+                                    image.mime_type,
+                                    image.to_base64(),
+                                )
+                            }
+                        }))
+                    }
+                    UserContentBlock::Image(_) => None,
+                })
+                .collect();
+
+            json!(parts)
+        }
+    }
+}
+
+fn convert_assistant_message(
+    assistant: &crate::types::AssistantMessage,
+) -> Option<serde_json::Value> {
+    let mut message = json!({
+        "role": "assistant",
+    });
+
+    let text_parts = assistant_text_parts(assistant);
+    if !text_parts.is_empty() {
+        message["content"] = json!(text_parts
+            .iter()
+            .map(|text| json!({ "type": "text", "text": text }))
+            .collect::<Vec<_>>());
+    }
+
+    let tool_calls = assistant_tool_calls(assistant);
+    if !tool_calls.is_empty() {
+        message["tool_calls"] = json!(tool_calls);
+    }
+
+    if message.get("content").is_none() && message.get("tool_calls").is_none() {
+        return None;
+    }
+
+    Some(message)
+}
+
+fn assistant_text_parts(assistant: &crate::types::AssistantMessage) -> Vec<String> {
+    assistant
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            Content::Text { inner } if !inner.text.is_empty() => Some(inner.text.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn assistant_tool_calls(assistant: &crate::types::AssistantMessage) -> Vec<serde_json::Value> {
+    assistant
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            Content::ToolCall { inner } => Some(json!({
+                "id": inner.id,
+                "type": "function",
+                "function": {
+                    "name": inner.name,
+                    "arguments": inner.arguments.to_string(),
+                }
+            })),
+            _ => None,
+        })
+        .collect()
+}
+
+fn convert_tool_result(
+    result: &crate::types::ToolResultMessage,
+    requires_tool_result_name: bool,
+) -> serde_json::Value {
+    let content = result
+        .content
+        .iter()
+        .filter_map(|item| match item {
+            ToolResultContent::Text(text) => Some(text.text.clone()),
+            ToolResultContent::Image(_) => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut message = json!({
+        "role": "tool",
+        "tool_call_id": result.tool_call_id,
+        "content": content,
+    });
+
+    if requires_tool_result_name {
+        message["name"] = json!(result.tool_name);
+    }
+
+    message
+}
+
+pub(crate) fn convert_tools(tools: &[Tool]) -> serde_json::Value {
+    let converted: Vec<serde_json::Value> = tools
+        .iter()
+        .map(|tool| {
+            json!({
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                    "strict": false,
+                }
+            })
+        })
+        .collect();
+
+    json!(converted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        Api, AssistantMessage, Cost, KnownProvider, ModelCost, OpenAICompletions, Provider,
+        StopReason, Usage,
+    };
+
+    fn make_model(input: Vec<InputType>) -> Model<OpenAICompletions> {
+        Model {
+            id: "test-model".to_string(),
+            name: "Test model".to_string(),
+            api: OpenAICompletions,
+            provider: Provider::Known(KnownProvider::OpenAI),
+            base_url: "https://example.com/v1/chat/completions".to_string(),
+            reasoning: false,
+            input,
+            cost: ModelCost {
+                input: 0.0,
+                output: 0.0,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            },
+            context_window: 128_000,
+            max_tokens: 4_096,
+            headers: None,
+            compat: None,
+        }
+    }
+
+    fn make_assistant_message() -> AssistantMessage {
+        AssistantMessage {
+            content: vec![Content::text("hello")],
+            api: Api::OpenAICompletions,
+            provider: Provider::Known(KnownProvider::OpenAI),
+            model: "test-model".to_string(),
+            usage: Usage {
+                input: 0,
+                output: 0,
+                cache_read: 0,
+                cache_write: 0,
+                total_tokens: 0,
+                cost: Cost::default(),
+            },
+            stop_reason: StopReason::Stop,
+            error_message: None,
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn convert_messages_uses_system_role_option() {
+        let model = make_model(vec![InputType::Text]);
+        let context = Context {
+            system_prompt: Some("sys".to_string()),
+            messages: vec![],
+            tools: None,
+        };
+
+        let params = convert_messages(
+            &model,
+            &context,
+            &OpenAiLikeMessageOptions {
+                system_role: SystemPromptRole::Developer,
+                requires_tool_result_name: false,
+            },
+        );
+
+        assert_eq!(params[0]["role"], "developer");
+        assert_eq!(params[0]["content"], "sys");
+    }
+
+    #[test]
+    fn convert_messages_drops_images_for_text_only_model() {
+        let model = make_model(vec![InputType::Text]);
+        let context = Context {
+            system_prompt: None,
+            messages: vec![Message::User(UserMessage {
+                content: UserContent::Multi(vec![UserContentBlock::Image(
+                    crate::types::ImageContent {
+                        data: vec![1, 2, 3],
+                        mime_type: "image/png".to_string(),
+                    },
+                )]),
+                timestamp: 0,
+            })],
+            tools: None,
+        };
+
+        let params = convert_messages(
+            &model,
+            &context,
+            &OpenAiLikeMessageOptions {
+                system_role: SystemPromptRole::System,
+                requires_tool_result_name: false,
+            },
+        );
+
+        assert_eq!(params[0]["content"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn convert_messages_includes_assistant_text_content() {
+        let model = make_model(vec![InputType::Text]);
+        let context = Context {
+            system_prompt: None,
+            messages: vec![Message::Assistant(make_assistant_message())],
+            tools: None,
+        };
+
+        let params = convert_messages(
+            &model,
+            &context,
+            &OpenAiLikeMessageOptions {
+                system_role: SystemPromptRole::System,
+                requires_tool_result_name: false,
+            },
+        );
+
+        assert_eq!(params[0]["role"], "assistant");
+        assert_eq!(params[0]["content"][0]["text"], "hello");
+    }
+}

--- a/src/providers/shared/openai_like_runtime.rs
+++ b/src/providers/shared/openai_like_runtime.rs
@@ -1,0 +1,143 @@
+use futures::StreamExt;
+use serde::de::DeserializeOwned;
+
+use crate::stream::EventStreamSender;
+use crate::types::{
+    Api, AssistantMessage, AssistantMessageEvent, Provider, StopReason, StopReasonError,
+    StopReasonSuccess, Usage,
+};
+
+use super::timestamp::unix_timestamp_millis;
+
+pub(crate) fn initialize_output(api: Api, provider: Provider, model: String) -> AssistantMessage {
+    AssistantMessage {
+        content: vec![],
+        api,
+        provider,
+        model,
+        usage: Usage::default(),
+        stop_reason: StopReason::Stop,
+        error_message: None,
+        timestamp: unix_timestamp_millis(),
+    }
+}
+
+pub(crate) fn push_stream_error(
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    error: crate::Error,
+) {
+    output.stop_reason = StopReason::Error;
+    output.error_message = Some(error.to_string());
+
+    sender.push(AssistantMessageEvent::Error {
+        reason: StopReasonError::Error,
+        error: output.clone(),
+    });
+}
+
+pub(crate) fn push_stream_done(output: &AssistantMessage, sender: &mut EventStreamSender) {
+    sender.push(AssistantMessageEvent::Done {
+        reason: done_reason_from_stop_reason(output.stop_reason),
+        message: output.clone(),
+    });
+}
+
+fn done_reason_from_stop_reason(stop_reason: StopReason) -> StopReasonSuccess {
+    match stop_reason {
+        StopReason::Stop => StopReasonSuccess::Stop,
+        StopReason::Length => StopReasonSuccess::Length,
+        StopReason::ToolUse => StopReasonSuccess::ToolUse,
+        _ => StopReasonSuccess::Stop,
+    }
+}
+
+pub(crate) async fn send_streaming_request(
+    client: &reqwest::Client,
+    base_url: &str,
+    params: &serde_json::Value,
+) -> Result<reqwest::Response, crate::Error> {
+    let response = client.post(base_url).json(params).send().await?;
+
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status_code = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+
+    Err(crate::Error::ApiError {
+        status_code,
+        message: body,
+    })
+}
+
+pub(crate) async fn process_sse_stream<TChunk, F>(
+    response: reqwest::Response,
+    mut on_chunk: F,
+) -> Result<(), crate::Error>
+where
+    TChunk: DeserializeOwned,
+    F: FnMut(TChunk),
+{
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+    let mut done_received = false;
+
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(line_end) = buffer.find('\n') {
+            let line = buffer[..line_end].trim().to_string();
+            buffer = buffer[line_end + 1..].to_string();
+
+            if line.is_empty() || line.starts_with(':') {
+                continue;
+            }
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                if data == "[DONE]" {
+                    done_received = true;
+                    break;
+                }
+
+                if let Ok(chunk) = serde_json::from_str::<TChunk>(data) {
+                    on_chunk(chunk);
+                }
+            }
+        }
+
+        if done_received {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::done_reason_from_stop_reason;
+    use crate::types::{StopReason, StopReasonSuccess};
+
+    #[test]
+    fn stop_reason_maps_to_done_reason() {
+        assert_eq!(
+            done_reason_from_stop_reason(StopReason::Stop),
+            StopReasonSuccess::Stop
+        );
+        assert_eq!(
+            done_reason_from_stop_reason(StopReason::Length),
+            StopReasonSuccess::Length
+        );
+        assert_eq!(
+            done_reason_from_stop_reason(StopReason::ToolUse),
+            StopReasonSuccess::ToolUse
+        );
+        assert_eq!(
+            done_reason_from_stop_reason(StopReason::Error),
+            StopReasonSuccess::Stop
+        );
+    }
+}

--- a/src/providers/shared/stream_blocks.rs
+++ b/src/providers/shared/stream_blocks.rs
@@ -1,0 +1,572 @@
+use serde::Deserialize;
+
+use crate::stream::EventStreamSender;
+use crate::types::{AssistantMessage, AssistantMessageEvent, Content, StopReason, ToolCall, Usage};
+
+#[derive(Debug)]
+pub(crate) enum CurrentBlock {
+    Text {
+        text: String,
+    },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
+    ToolCall {
+        id: String,
+        name: String,
+        partial_args: String,
+    },
+}
+
+pub(crate) struct ReasoningDelta<'a> {
+    pub text: &'a str,
+    pub signature: &'a str,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct OpenAiLikeToolCallDelta {
+    pub id: Option<String>,
+    pub function: Option<OpenAiLikeFunctionDelta>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct OpenAiLikeFunctionDelta {
+    pub name: Option<String>,
+    pub arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiLikeStreamUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: Option<u32>,
+    pub cache_read_input_tokens: Option<u32>,
+    pub cache_creation_input_tokens: Option<u32>,
+    pub cost: Option<f64>,
+    pub cost_details: Option<StreamCostDetails>,
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+    #[serde(rename = "completion_tokens_details")]
+    _completion_tokens_details: Option<CompletionTokensDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StreamCostDetails {
+    upstream_inference_prompt_cost: Option<f64>,
+    upstream_inference_completions_cost: Option<f64>,
+    upstream_inference_cost: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PromptTokensDetails {
+    cached_tokens: Option<u32>,
+    cache_write_tokens: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompletionTokensDetails {
+    #[serde(rename = "reasoning_tokens")]
+    _reasoning_tokens: Option<u32>,
+}
+
+pub(crate) fn update_usage_from_chunk(
+    usage: &OpenAiLikeStreamUsage,
+    output: &mut AssistantMessage,
+) {
+    let cache_read_tokens = usage
+        .cache_read_input_tokens
+        .or_else(|| {
+            usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|details| details.cached_tokens)
+        })
+        .unwrap_or(0);
+
+    let cache_write_tokens = usage
+        .cache_creation_input_tokens
+        .or_else(|| {
+            usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|details| details.cache_write_tokens)
+        })
+        .unwrap_or(0);
+
+    let input_tokens = usage.prompt_tokens;
+    let output_tokens = usage.completion_tokens;
+    let total_tokens = usage.total_tokens.unwrap_or(input_tokens + output_tokens);
+
+    let cost_input = usage
+        .cost_details
+        .as_ref()
+        .and_then(|details| details.upstream_inference_prompt_cost)
+        .unwrap_or(0.0);
+
+    let cost_output = usage
+        .cost_details
+        .as_ref()
+        .and_then(|details| details.upstream_inference_completions_cost)
+        .unwrap_or(0.0);
+
+    let cost_cache_read = 0.0;
+    let cost_cache_write = 0.0;
+
+    let has_component_cost = usage.cost_details.as_ref().is_some_and(|details| {
+        details.upstream_inference_prompt_cost.is_some()
+            || details.upstream_inference_completions_cost.is_some()
+    });
+
+    let component_total_cost =
+        has_component_cost.then_some(cost_input + cost_output + cost_cache_read + cost_cache_write);
+
+    let cost_total = usage
+        .cost_details
+        .as_ref()
+        .and_then(|details| details.upstream_inference_cost)
+        .or(usage.cost)
+        .or(component_total_cost)
+        .unwrap_or(0.0);
+
+    output.usage = Usage {
+        input: input_tokens,
+        output: output_tokens,
+        cache_read: cache_read_tokens,
+        cache_write: cache_write_tokens,
+        total_tokens,
+        cost: crate::types::Cost {
+            input: cost_input,
+            output: cost_output,
+            cache_read: cost_cache_read,
+            cache_write: cost_cache_write,
+            total: cost_total,
+        },
+    };
+}
+
+pub(crate) fn handle_text_delta(
+    content: &str,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    if content.is_empty() {
+        return;
+    }
+
+    match current_block {
+        Some(CurrentBlock::Text { text }) => {
+            text.push_str(content);
+            sender.push(AssistantMessageEvent::TextDelta {
+                content_index: output.content.len().saturating_sub(1),
+                delta: content.to_string(),
+                partial: output.clone(),
+            });
+        }
+        _ => {
+            finish_current_block(current_block, output, sender);
+
+            let text = content.to_string();
+            *current_block = Some(CurrentBlock::Text { text: text.clone() });
+            output.content.push(Content::text(""));
+            let content_index = output.content.len() - 1;
+
+            sender.push(AssistantMessageEvent::TextStart {
+                content_index,
+                partial: output.clone(),
+            });
+            sender.push(AssistantMessageEvent::TextDelta {
+                content_index,
+                delta: text,
+                partial: output.clone(),
+            });
+        }
+    }
+}
+
+pub(crate) fn handle_reasoning_delta(
+    reasoning: ReasoningDelta<'_>,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    if reasoning.text.is_empty() {
+        return;
+    }
+
+    match current_block {
+        Some(CurrentBlock::Thinking { thinking, .. }) => {
+            thinking.push_str(reasoning.text);
+            sender.push(AssistantMessageEvent::ThinkingDelta {
+                content_index: output.content.len().saturating_sub(1),
+                delta: reasoning.text.to_string(),
+                partial: output.clone(),
+            });
+        }
+        _ => {
+            finish_current_block(current_block, output, sender);
+
+            let thinking = reasoning.text.to_string();
+            *current_block = Some(CurrentBlock::Thinking {
+                thinking: thinking.clone(),
+                signature: reasoning.signature.to_string(),
+            });
+            output.content.push(Content::thinking(""));
+            let content_index = output.content.len() - 1;
+
+            sender.push(AssistantMessageEvent::ThinkingStart {
+                content_index,
+                partial: output.clone(),
+            });
+            sender.push(AssistantMessageEvent::ThinkingDelta {
+                content_index,
+                delta: thinking,
+                partial: output.clone(),
+            });
+        }
+    }
+}
+
+pub(crate) fn handle_tool_calls(
+    tool_calls: &[OpenAiLikeToolCallDelta],
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    for tool_call in tool_calls {
+        if should_start_new_tool_call(current_block, tool_call) {
+            start_tool_call_block(tool_call, output, sender, current_block);
+        }
+
+        apply_tool_call_delta(tool_call, output, sender, current_block);
+    }
+}
+
+fn should_start_new_tool_call(
+    current_block: &Option<CurrentBlock>,
+    tool_call: &OpenAiLikeToolCallDelta,
+) -> bool {
+    match current_block {
+        Some(CurrentBlock::ToolCall { id, .. }) => {
+            tool_call.id.as_ref().is_some_and(|new_id| new_id != id)
+        }
+        _ => true,
+    }
+}
+
+fn start_tool_call_block(
+    tool_call: &OpenAiLikeToolCallDelta,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    finish_current_block(current_block, output, sender);
+
+    let id = tool_call.id.clone().unwrap_or_default();
+    let name = tool_call
+        .function
+        .as_ref()
+        .and_then(|function| function.name.clone())
+        .unwrap_or_default();
+
+    *current_block = Some(CurrentBlock::ToolCall {
+        id: id.clone(),
+        name: name.clone(),
+        partial_args: String::new(),
+    });
+
+    output.content.push(Content::tool_call(
+        id,
+        name,
+        serde_json::Value::Object(serde_json::Map::new()),
+    ));
+
+    sender.push(AssistantMessageEvent::ToolCallStart {
+        content_index: output.content.len() - 1,
+        partial: output.clone(),
+    });
+}
+
+fn apply_tool_call_delta(
+    tool_call: &OpenAiLikeToolCallDelta,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    let Some(CurrentBlock::ToolCall {
+        id,
+        name,
+        partial_args,
+    }) = current_block
+    else {
+        return;
+    };
+
+    if let Some(new_id) = &tool_call.id {
+        *id = new_id.clone();
+    }
+
+    if let Some(function) = &tool_call.function {
+        if let Some(new_name) = &function.name {
+            *name = new_name.clone();
+        }
+
+        if let Some(arguments) = &function.arguments {
+            partial_args.push_str(arguments);
+
+            sender.push(AssistantMessageEvent::ToolCallDelta {
+                content_index: output.content.len() - 1,
+                delta: arguments.clone(),
+                partial: output.clone(),
+            });
+        }
+    }
+}
+
+pub(crate) fn finish_current_block(
+    current_block: &mut Option<CurrentBlock>,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+) {
+    let Some(block) = current_block.take() else {
+        return;
+    };
+
+    let content_index = output.content.len().saturating_sub(1);
+
+    match block {
+        CurrentBlock::Text { text } => {
+            if let Some(Content::Text { inner }) = output.content.get_mut(content_index) {
+                inner.text = text.clone();
+            }
+
+            sender.push(AssistantMessageEvent::TextEnd {
+                content_index,
+                content: text,
+                partial: output.clone(),
+            });
+        }
+        CurrentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            if let Some(Content::Thinking { inner }) = output.content.get_mut(content_index) {
+                inner.thinking = thinking.clone();
+                inner.thinking_signature = Some(signature);
+            }
+
+            sender.push(AssistantMessageEvent::ThinkingEnd {
+                content_index,
+                content: thinking,
+                partial: output.clone(),
+            });
+        }
+        CurrentBlock::ToolCall {
+            id,
+            name,
+            partial_args,
+        } => {
+            let arguments: serde_json::Value = serde_json::from_str(&partial_args)
+                .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
+
+            if let Some(Content::ToolCall { inner }) = output.content.get_mut(content_index) {
+                inner.id = id.clone();
+                inner.name = name.clone();
+                inner.arguments = arguments.clone();
+            }
+
+            sender.push(AssistantMessageEvent::ToolCallEnd {
+                content_index,
+                tool_call: ToolCall {
+                    id,
+                    name,
+                    arguments,
+                    thought_signature: None,
+                },
+                partial: output.clone(),
+            });
+        }
+    }
+}
+
+pub(crate) fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "stop" => StopReason::Stop,
+        "length" => StopReason::Length,
+        "function_call" | "tool_calls" => StopReason::ToolUse,
+        "content_filter" => StopReason::Error,
+        _ => StopReason::Stop,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Api, KnownProvider, Provider};
+
+    fn make_output_message() -> AssistantMessage {
+        AssistantMessage {
+            content: vec![],
+            api: Api::OpenAICompletions,
+            provider: Provider::Known(KnownProvider::OpenAI),
+            model: "test-model".to_string(),
+            usage: Usage::default(),
+            stop_reason: StopReason::Stop,
+            error_message: None,
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn map_stop_reason_matches_openai_contract() {
+        assert_eq!(map_stop_reason("stop"), StopReason::Stop);
+        assert_eq!(map_stop_reason("length"), StopReason::Length);
+        assert_eq!(map_stop_reason("tool_calls"), StopReason::ToolUse);
+        assert_eq!(map_stop_reason("function_call"), StopReason::ToolUse);
+        assert_eq!(map_stop_reason("content_filter"), StopReason::Error);
+        assert_eq!(map_stop_reason("unknown"), StopReason::Stop);
+    }
+
+    #[test]
+    fn update_usage_uses_provider_raw_totals() {
+        let usage: OpenAiLikeStreamUsage = serde_json::from_value(serde_json::json!({
+            "prompt_tokens": 79,
+            "completion_tokens": 114,
+            "completion_tokens_details": {
+                "reasoning_tokens": 91
+            },
+            "total_tokens": 193
+        }))
+        .expect("valid usage payload");
+
+        let mut output = make_output_message();
+        update_usage_from_chunk(&usage, &mut output);
+
+        assert_eq!(output.usage.input, 79);
+        assert_eq!(output.usage.output, 114);
+        assert_eq!(output.usage.total_tokens, 193);
+    }
+
+    #[test]
+    fn update_usage_uses_provider_cache_tokens_when_present() {
+        let usage: OpenAiLikeStreamUsage = serde_json::from_value(serde_json::json!({
+            "prompt_tokens": 100,
+            "completion_tokens": 25,
+            "total_tokens": 125,
+            "cache_read_input_tokens": 12,
+            "cache_creation_input_tokens": 9,
+            "prompt_tokens_details": {
+                "cached_tokens": 7,
+                "cache_write_tokens": 5
+            }
+        }))
+        .expect("valid usage payload");
+
+        let mut output = make_output_message();
+        update_usage_from_chunk(&usage, &mut output);
+
+        assert_eq!(output.usage.cache_read, 12);
+        assert_eq!(output.usage.cache_write, 9);
+    }
+
+    #[test]
+    fn update_usage_falls_back_to_prompt_details() {
+        let usage: OpenAiLikeStreamUsage = serde_json::from_value(serde_json::json!({
+            "prompt_tokens": 80,
+            "completion_tokens": 20,
+            "prompt_tokens_details": {
+                "cached_tokens": 15,
+                "cache_write_tokens": 4
+            }
+        }))
+        .expect("valid usage payload");
+
+        let mut output = make_output_message();
+        update_usage_from_chunk(&usage, &mut output);
+
+        assert_eq!(output.usage.cache_read, 15);
+        assert_eq!(output.usage.cache_write, 4);
+        assert_eq!(output.usage.total_tokens, 100);
+    }
+
+    #[test]
+    fn update_usage_maps_cost_details() {
+        let usage: OpenAiLikeStreamUsage = serde_json::from_value(serde_json::json!({
+            "prompt_tokens": 16,
+            "completion_tokens": 4,
+            "total_tokens": 20,
+            "cost": 0.0001782,
+            "cost_details": {
+                "upstream_inference_prompt_cost": 0.00008,
+                "upstream_inference_completions_cost": 0.0001,
+                "upstream_inference_cost": 0.00018
+            }
+        }))
+        .expect("valid usage payload");
+
+        let mut output = make_output_message();
+        update_usage_from_chunk(&usage, &mut output);
+
+        assert_eq!(output.usage.cost.input, 0.00008);
+        assert_eq!(output.usage.cost.output, 0.0001);
+        assert_eq!(output.usage.cost.total, 0.00018);
+    }
+
+    #[test]
+    fn update_usage_uses_top_level_cost_when_details_missing() {
+        let usage: OpenAiLikeStreamUsage = serde_json::from_value(serde_json::json!({
+            "prompt_tokens": 16,
+            "completion_tokens": 4,
+            "total_tokens": 20,
+            "cost": 0.0001782
+        }))
+        .expect("valid usage payload");
+
+        let mut output = make_output_message();
+        update_usage_from_chunk(&usage, &mut output);
+
+        assert_eq!(output.usage.cost.input, 0.0);
+        assert_eq!(output.usage.cost.output, 0.0);
+        assert_eq!(output.usage.cost.total, 0.0001782);
+    }
+
+    #[test]
+    fn update_usage_falls_back_to_component_sum_when_total_missing() {
+        let usage: OpenAiLikeStreamUsage = serde_json::from_value(serde_json::json!({
+            "prompt_tokens": 16,
+            "completion_tokens": 4,
+            "total_tokens": 20,
+            "cost_details": {
+                "upstream_inference_prompt_cost": 0.00008,
+                "upstream_inference_completions_cost": 0.0001
+            }
+        }))
+        .expect("valid usage payload");
+
+        let mut output = make_output_message();
+        update_usage_from_chunk(&usage, &mut output);
+
+        assert_eq!(output.usage.cost.input, 0.00008);
+        assert_eq!(output.usage.cost.output, 0.0001);
+        assert_eq!(output.usage.cost.total, 0.00018);
+    }
+
+    #[test]
+    fn update_usage_defaults_cost_to_zero_when_missing() {
+        let usage: OpenAiLikeStreamUsage = serde_json::from_value(serde_json::json!({
+            "prompt_tokens": 16,
+            "completion_tokens": 4,
+            "total_tokens": 20
+        }))
+        .expect("valid usage payload");
+
+        let mut output = make_output_message();
+        update_usage_from_chunk(&usage, &mut output);
+
+        assert_eq!(output.usage.cost.input, 0.0);
+        assert_eq!(output.usage.cost.output, 0.0);
+        assert_eq!(output.usage.cost.cache_read, 0.0);
+        assert_eq!(output.usage.cost.cache_write, 0.0);
+        assert_eq!(output.usage.cost.total, 0.0);
+    }
+}

--- a/src/types/api.rs
+++ b/src/types/api.rs
@@ -9,6 +9,7 @@ pub enum Api {
     BedrockConverseStream,
     OpenAICompletions,
     OpenAIResponses,
+    MinimaxCompletions,
     GoogleGenerativeAi,
     GoogleVertex,
 }
@@ -20,6 +21,7 @@ impl Display for Api {
             Self::BedrockConverseStream => write!(f, "bedrock-converse-stream"),
             Self::OpenAICompletions => write!(f, "openai-completions"),
             Self::OpenAIResponses => write!(f, "openai-responses"),
+            Self::MinimaxCompletions => write!(f, "minimax-completions"),
             Self::GoogleGenerativeAi => write!(f, "google-generative-ai"),
             Self::GoogleVertex => write!(f, "google-vertex"),
         }
@@ -35,6 +37,7 @@ impl FromStr for Api {
             "bedrock-converse-stream" => Ok(Self::BedrockConverseStream),
             "openai-completions" => Ok(Self::OpenAICompletions),
             "openai-responses" => Ok(Self::OpenAIResponses),
+            "minimax-completions" => Ok(Self::MinimaxCompletions),
             "google-generative-ai" => Ok(Self::GoogleGenerativeAi),
             "google-vertex" => Ok(Self::GoogleVertex),
             _ => Err(crate::Error::UnknownApi(s.to_string())),
@@ -175,5 +178,18 @@ pub struct NoCompat;
 impl CompatibilityOptions for NoCompat {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Api;
+    use std::str::FromStr;
+
+    #[test]
+    fn minimax_completions_api_round_trip() {
+        let parsed = Api::from_str("minimax-completions").expect("valid minimax API variant");
+        assert_eq!(parsed, Api::MinimaxCompletions);
+        assert_eq!(parsed.to_string(), "minimax-completions");
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,8 +17,8 @@ pub use message::{
     UserContentBlock, UserMessage,
 };
 pub use model::{
-    AnthropicMessages, BedrockConverseStream, GoogleGenerativeAi, GoogleVertex, InputType, Model,
-    OpenAICompletions, OpenAIResponses,
+    AnthropicMessages, BedrockConverseStream, GoogleGenerativeAi, GoogleVertex, InputType,
+    MinimaxCompletions, Model, OpenAICompletions, OpenAIResponses,
 };
 pub use options::{SimpleStreamOptions, StreamOptions, ThinkingLevel};
 pub use tool::Tool;

--- a/src/types/model.rs
+++ b/src/types/model.rs
@@ -73,6 +73,17 @@ impl ApiType for OpenAIResponses {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub struct MinimaxCompletions;
+
+impl ApiType for MinimaxCompletions {
+    type Compat = NoCompat;
+
+    fn api(&self) -> Api {
+        Api::MinimaxCompletions
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct GoogleGenerativeAi;
 
 impl ApiType for GoogleGenerativeAi {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,9 +9,11 @@
 pub mod json_parse;
 pub mod overflow;
 pub mod sanitize;
+pub mod think_tag_parser;
 pub mod validation;
 
 pub use json_parse::{parse_streaming_json, parse_streaming_json_smart};
 pub use overflow::{get_overflow_patterns, is_context_overflow};
 pub use sanitize::{sanitize_for_api, sanitize_surrogates};
+pub use think_tag_parser::{ThinkFragment, ThinkTagParser};
 pub use validation::{validate_tool_arguments, validate_tool_call};

--- a/src/utils/think_tag_parser.rs
+++ b/src/utils/think_tag_parser.rs
@@ -1,0 +1,223 @@
+const OPEN_THINK_TAG: &str = "<think>";
+const CLOSE_THINK_TAG: &str = "</think>";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThinkFragment {
+    Text(String),
+    Thinking(String),
+}
+
+#[derive(Debug, Default)]
+pub struct ThinkTagParser {
+    buffer: String,
+    in_thinking_block: bool,
+}
+
+impl ThinkTagParser {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn feed(&mut self, chunk: &str) -> Vec<ThinkFragment> {
+        self.buffer.push_str(chunk);
+
+        let mut fragments = Vec::new();
+
+        loop {
+            let emitted = if self.in_thinking_block {
+                self.emit_thinking_fragment(&mut fragments)
+            } else {
+                self.emit_text_fragment(&mut fragments)
+            };
+
+            if !emitted {
+                break;
+            }
+        }
+
+        fragments
+    }
+
+    pub fn flush(&mut self) -> Vec<ThinkFragment> {
+        let mut fragments = Vec::new();
+
+        if self.buffer.is_empty() {
+            self.in_thinking_block = false;
+            return fragments;
+        }
+
+        let pending = std::mem::take(&mut self.buffer);
+
+        if self.in_thinking_block {
+            fragments.push(ThinkFragment::Thinking(pending));
+        } else {
+            fragments.push(ThinkFragment::Text(pending));
+        }
+
+        self.in_thinking_block = false;
+        fragments
+    }
+
+    fn emit_text_fragment(&mut self, fragments: &mut Vec<ThinkFragment>) -> bool {
+        if let Some(tag_index) = self.buffer.find(OPEN_THINK_TAG) {
+            self.push_non_empty_text(&self.buffer[..tag_index], fragments);
+            self.buffer.drain(..tag_index + OPEN_THINK_TAG.len());
+            self.in_thinking_block = true;
+            return true;
+        }
+
+        let partial_suffix = partial_tag_suffix_len(&self.buffer, OPEN_THINK_TAG);
+        let safe_len = self.buffer.len().saturating_sub(partial_suffix);
+
+        if safe_len == 0 {
+            return false;
+        }
+
+        self.push_non_empty_text(&self.buffer[..safe_len], fragments);
+        self.buffer.drain(..safe_len);
+
+        false
+    }
+
+    fn emit_thinking_fragment(&mut self, fragments: &mut Vec<ThinkFragment>) -> bool {
+        if let Some(tag_index) = self.buffer.find(CLOSE_THINK_TAG) {
+            self.push_non_empty_thinking(&self.buffer[..tag_index], fragments);
+            self.buffer.drain(..tag_index + CLOSE_THINK_TAG.len());
+            self.in_thinking_block = false;
+            return true;
+        }
+
+        let partial_suffix = partial_tag_suffix_len(&self.buffer, CLOSE_THINK_TAG);
+        let safe_len = self.buffer.len().saturating_sub(partial_suffix);
+
+        if safe_len == 0 {
+            return false;
+        }
+
+        self.push_non_empty_thinking(&self.buffer[..safe_len], fragments);
+        self.buffer.drain(..safe_len);
+
+        false
+    }
+
+    fn push_non_empty_text(&self, text: &str, fragments: &mut Vec<ThinkFragment>) {
+        if text.is_empty() {
+            return;
+        }
+
+        fragments.push(ThinkFragment::Text(text.to_string()));
+    }
+
+    fn push_non_empty_thinking(&self, thinking: &str, fragments: &mut Vec<ThinkFragment>) {
+        if thinking.is_empty() {
+            return;
+        }
+
+        fragments.push(ThinkFragment::Thinking(thinking.to_string()));
+    }
+}
+
+fn partial_tag_suffix_len(input: &str, tag: &str) -> usize {
+    let max_suffix_len = input.len().min(tag.len().saturating_sub(1));
+
+    for suffix_len in (1..=max_suffix_len).rev() {
+        if input.ends_with(&tag[..suffix_len]) {
+            return suffix_len;
+        }
+    }
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ThinkFragment, ThinkTagParser};
+
+    #[test]
+    fn parses_inline_think_block_and_text() {
+        let mut parser = ThinkTagParser::new();
+
+        let fragments = parser.feed("<think>reason</think>answer");
+
+        assert_eq!(
+            fragments,
+            vec![
+                ThinkFragment::Thinking("reason".to_string()),
+                ThinkFragment::Text("answer".to_string()),
+            ]
+        );
+        assert!(parser.flush().is_empty());
+    }
+
+    #[test]
+    fn handles_split_open_tag_boundaries() {
+        let mut parser = ThinkTagParser::new();
+
+        assert!(parser.feed("<th").is_empty());
+        assert_eq!(
+            parser.feed("ink>reason"),
+            vec![ThinkFragment::Thinking("reason".to_string())]
+        );
+        assert_eq!(
+            parser.feed("</think>done"),
+            vec![ThinkFragment::Text("done".to_string())]
+        );
+    }
+
+    #[test]
+    fn handles_split_close_tag_boundaries() {
+        let mut parser = ThinkTagParser::new();
+
+        assert_eq!(
+            parser.feed("<think>rea"),
+            vec![ThinkFragment::Thinking("rea".to_string())]
+        );
+        assert_eq!(
+            parser.feed("son</th"),
+            vec![ThinkFragment::Thinking("son".to_string())]
+        );
+        assert_eq!(
+            parser.feed("ink>text"),
+            vec![ThinkFragment::Text("text".to_string())]
+        );
+    }
+
+    #[test]
+    fn flushes_false_start_as_text() {
+        let mut parser = ThinkTagParser::new();
+
+        assert_eq!(
+            parser.feed("hello <thi"),
+            vec![ThinkFragment::Text("hello ".to_string())]
+        );
+        assert_eq!(
+            parser.flush(),
+            vec![ThinkFragment::Text("<thi".to_string())]
+        );
+    }
+
+    #[test]
+    fn drops_empty_thinking_segments() {
+        let mut parser = ThinkTagParser::new();
+
+        assert_eq!(
+            parser.feed("<think></think>answer"),
+            vec![ThinkFragment::Text("answer".to_string())]
+        );
+    }
+
+    #[test]
+    fn flush_resets_mode_for_next_chunk() {
+        let mut parser = ThinkTagParser::new();
+
+        assert_eq!(
+            parser.feed("<think>reason"),
+            vec![ThinkFragment::Thinking("reason".to_string())]
+        );
+        assert!(parser.flush().is_empty());
+        assert_eq!(
+            parser.feed("next"),
+            vec![ThinkFragment::Text("next".to_string())]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- implement MiniMax as a first-class API (`Api::MinimaxCompletions`) and provider (`src/providers/minimax.rs`)
- add dispatch + exports wiring for MiniMax stream path
- extract OpenAI-like shared helpers into `src/providers/shared/*` to avoid OpenAI/MiniMax duplication
- add MiniMax model catalog in `src/models/minimax.rs`
- add `<think>` fallback parser utility and MiniMax stream parsing for `reasoning_details` + usage-only chunk
- add live MiniMax examples and `smokescripts/` runner scripts

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `make complexity`
- `make duplicates`
- live smoke runs:
  - `bash smokescripts/run_minimax_reasoning_split.sh`
  - `bash smokescripts/run_minimax_inline_think.sh`
  - `bash smokescripts/run_minimax_usage_chunk.sh`

## Note
Documentation updates will be pushed in a follow-up after this PR is merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MiniMax models (M2.5, M2.1, M2) with global and CN variants, including highspeed versions.
  * Introduced structured OpenAICompletionsOptions for API configuration.
  * Added ThinkTagParser utility for parsing inline thinking tags.

* **Documentation**
  * Added example programs demonstrating MiniMax streaming with reasoning_split, inline thinking, and usage tracking.
  * Added documentation and helper scripts for running MiniMax examples.
  * Updated README with new API usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->