### PR TITLE
docs: sync docs with PR #37 z.ai integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- First-class z.ai GLM provider integration via `Api::ZaiCompletions` and `stream_zai_completions`
+- Built-in z.ai GLM model constructors (`glm_5`, `glm_4_7`, `glm_4_5_*`, `glm_4_32b_0414_128k`)
+- New z.ai examples: `examples/zai_glm_simple_chat.rs` and `examples/zai_glm_tool_call_smoke.rs`
+- Ast-grep architecture boundary checks under `rules/` with `make ast-rules`
+
+### Changed
+- Event stream primitives (`AssistantMessageEventStream`, `EventStreamSender`) are now defined in `src/types/event_stream.rs` and re-exported from `types`
+
 ## [0.1.6] - 2026-02-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ A unified LLM API abstraction layer in Rust that supports 10+ providers through 
 - **Groq**
 - **Cerebras**
 - **OpenRouter**
+- **z.ai** (GLM)
 
-> Current first-class streaming implementations in Rust: **OpenAI Completions** and **MiniMax Completions**. Other provider APIs are being ported incrementally.
+> Current first-class streaming implementations in Rust: **OpenAI Completions**, **MiniMax Completions**, and **z.ai Completions**. Other provider APIs are being ported incrementally.
 
 ## Features
 
@@ -106,11 +107,20 @@ async fn main() -> alchemy_llm::Result<()> {
 
 - **Crate:** [alchemy-llm on crates.io](https://crates.io/crates/alchemy-llm)
 - **Docs:** [docs.rs/alchemy-llm](https://docs.rs/alchemy-llm)
-- Current version: `0.1.5`
-- Release notes: [CHANGELOG.md](./CHANGELOG.md#015---2026-02-21)
+- Current version: `0.1.6`
+- Release notes: [CHANGELOG.md](./CHANGELOG.md#016---2026-02-21)
 - Highlights:
-  - Add first-class `ToolCallId` type for unified tool-call identity
-  - Add cross-provider tool-call smoke flow (OpenRouter, MiniMax, Chutes) with full typed response output
+  - Fix MiniMax streamed tool-call argument continuation across interleaved chunks
+  - Add regression coverage for MiniMax/id-less tool-call continuation handling
+
+## Main Branch Updates (post-0.1.6)
+
+- First-class z.ai GLM provider via `Api::ZaiCompletions`
+- Built-in GLM constructors (`glm_5`, `glm_4_7`, `glm_4_5_*`, etc.)
+- New live examples:
+  - `examples/zai_glm_simple_chat.rs`
+  - `examples/zai_glm_tool_call_smoke.rs`
+- Ast-grep architecture boundary checks under `rules/` (`make ast-rules`)
 
 ## Setup
 
@@ -151,11 +161,15 @@ async fn main() -> alchemy_llm::Result<()> {
 | `minimax_live_reasoning_split` | Live MiniMax stream with `reasoning_split` enabled |
 | `minimax_live_inline_think` | Live MiniMax stream exercising `<think>` fallback parsing |
 | `minimax_live_usage_chunk` | Live MiniMax final message + usage summary |
+| `zai_glm_simple_chat` | Live z.ai GLM chat with thinking/text event output |
+| `zai_glm_tool_call_smoke` | Live z.ai GLM tool-call smoke for unified tool events |
+| `tool_call_unified_types_smoke` | Cross-provider typed tool-call stream/output smoke |
 
 ## Documentation
 
 - [docs/README.md](./docs/README.md) - Documentation index
 - [docs/providers/minimax.md](./docs/providers/minimax.md) - MiniMax provider guide
+- [docs/providers/zai.md](./docs/providers/zai.md) - z.ai GLM provider guide
 - [docs/api/lib.md](./docs/api/lib.md) - Public API surface
 - [docs/utils/transform.md](./docs/utils/transform.md) - Message transformation guide
 
@@ -172,10 +186,11 @@ Pre-commit hooks automatically run:
 
 Run all quality checks:
 ```bash
-make quality-full     # All checks including complexity and duplicates
+make quality-full     # All checks including complexity, duplicates, and ast-rules
 make quality-quick    # Fast checks (fmt, clippy, check)
 make complexity       # Cyclomatic complexity analysis
 make duplicates       # Duplicate code detection
+make ast-rules        # Ast-grep architecture boundary checks
 ```
 
 Or run individually:
@@ -183,11 +198,13 @@ Or run individually:
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo check --all-targets --all-features
+make ast-rules
 ```
 
 **Tools used:**
 - **Clippy** - Cognitive complexity warnings (threshold: 20)
 - **polydup** - Duplicate code detection (install: `cargo install polydup-cli`)
+- **ast-grep (`sg`)** - Architecture boundary checks (`make ast-rules`)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,20 +17,27 @@ read_when:
 ## Provider Guides
 
 - [providers/minimax.md](./providers/minimax.md) - First-class MiniMax provider (global + CN)
+- [providers/zai.md](./providers/zai.md) - First-class z.ai GLM provider
 
 ## Utilities
 
 - [utils/transform.md](./utils/transform.md) - Cross-provider conversation transformation
 
-## Latest Release (0.1.5)
+## Latest Release (0.1.6)
 
-The latest published crate release adds first-class tool-call ID typing and cross-provider smoke coverage:
+The latest published crate release focuses on MiniMax streamed tool-call correctness:
 
-- New canonical `ToolCallId` type (`src/types/tool_call_id.rs`)
-- `ToolCall.id` and `ToolResultMessage.tool_call_id` now use `ToolCallId`
-- Unified cross-provider smoke flow for OpenRouter + MiniMax + Chutes
-- Full typed stream/event output in `smokescripts/run_tool_call_unified_types.sh`
+- Interleaved tool-call argument deltas are now merged reliably
+- Id-less continuation chunks are handled consistently in the shared stream parser
+- Regression tests cover continuation + reasoning/text interleave scenarios
 
-For release details, see [../CHANGELOG.md](../CHANGELOG.md#015---2026-02-21).
+For release details, see [../CHANGELOG.md](../CHANGELOG.md#016---2026-02-21).
 
-For MiniMax-specific documentation from the previous release train, see [providers/minimax.md](./providers/minimax.md).
+## Main Branch Updates (post-0.1.6)
+
+- New first-class z.ai provider path (`Api::ZaiCompletions`)
+- New built-in GLM model constructors in `src/models/zai.rs`
+- New z.ai examples:
+  - `examples/zai_glm_simple_chat.rs`
+  - `examples/zai_glm_tool_call_smoke.rs`
+- Architecture boundary checks via ast-grep rules in `rules/`

--- a/docs/api/lib.md
+++ b/docs/api/lib.md
@@ -3,7 +3,7 @@ summary: "Public API surface with crate modules, provider entry points, model co
 read_when:
   - You want to understand what `alchemy_llm` exports from `src/lib.rs`
   - You need the correct import path for stream functions and core types
-  - You want to discover built-in MiniMax model constructors
+  - You want to discover built-in MiniMax and z.ai model constructors
 ---
 
 # Public API (`src/lib.rs`)
@@ -36,9 +36,10 @@ pub use error::{Error, Result};
 
 ```rust
 pub use models::{
-    minimax_cn_m2, minimax_cn_m2_1, minimax_cn_m2_1_highspeed, minimax_cn_m2_5,
-    minimax_cn_m2_5_highspeed, minimax_m2, minimax_m2_1, minimax_m2_1_highspeed,
-    minimax_m2_5, minimax_m2_5_highspeed,
+    glm_4_32b_0414_128k, glm_4_5, glm_4_5_air, glm_4_5_airx, glm_4_5_flash, glm_4_5_x,
+    glm_4_6, glm_4_7, glm_4_7_flash, glm_4_7_flashx, glm_5, minimax_cn_m2, minimax_cn_m2_1,
+    minimax_cn_m2_1_highspeed, minimax_cn_m2_5, minimax_cn_m2_5_highspeed, minimax_m2,
+    minimax_m2_1, minimax_m2_1_highspeed, minimax_m2_5, minimax_m2_5_highspeed,
 };
 ```
 
@@ -51,6 +52,18 @@ pub use providers::{
     stream_openai_completions,
     OpenAICompletionsOptions,
 };
+```
+
+`src/providers/mod.rs` also exports z.ai-specific streaming:
+
+```rust
+pub use zai::stream_zai_completions;
+```
+
+Use it via module path:
+
+```rust
+use alchemy_llm::providers::stream_zai_completions;
 ```
 
 ### Stream Entry Points
@@ -123,6 +136,7 @@ async fn main() -> alchemy_llm::Result<()> {
 ## Notes
 
 - `stream()` resolves API keys from options first, then environment variables via `get_env_api_key()`.
+- `stream()` dispatches first-class paths for `Api::OpenAICompletions`, `Api::MinimaxCompletions`, and `Api::ZaiCompletions`.
 - `complete()` is a convenience wrapper around `stream()` that returns the final `AssistantMessage`.
 - `types::*` contains the canonical cross-provider event/message contracts used by all providers.
 - Tool-call identity is modeled via `types::ToolCallId` and is shared by both `ToolCall.id` and `ToolResultMessage.tool_call_id`.

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -1,0 +1,161 @@
+---
+summary: "First-class z.ai GLM provider guide: models, config, streaming behavior, and tool-call support"
+read_when:
+  - You want to use z.ai GLM models with `alchemy_llm`
+  - You need z.ai-specific options (`thinking`, `tool_stream`, `response_format`, etc.)
+  - You want to verify unified thinking/tool-call event behavior
+---
+
+# z.ai Provider Guide
+
+## What was added in PR #37
+
+z.ai is now a first-class provider path in Rust:
+
+- `Api::ZaiCompletions`
+- Dedicated provider implementation: `src/providers/zai.rs`
+- Built-in GLM model constructors: `src/models/zai.rs`
+- New examples:
+  - `examples/zai_glm_simple_chat.rs`
+  - `examples/zai_glm_tool_call_smoke.rs`
+
+## Environment Variable
+
+| Provider | Env var |
+|---|---|
+| `KnownProvider::Zai` | `ZAI_API_KEY` |
+
+`stream()` resolves API keys from options first, then falls back to environment variables.
+
+## Built-in z.ai Models
+
+All built-in GLM constructors:
+
+- use `Api::ZaiCompletions`
+- use provider `KnownProvider::Zai`
+- default `reasoning = true`
+- default `InputType::Text`
+- use base URL: `https://api.z.ai/api/paas/v4/chat/completions`
+
+### 200K context / 128K max output
+
+- `glm_5()`
+- `glm_4_7()`
+- `glm_4_7_flash()`
+- `glm_4_7_flashx()`
+- `glm_4_6()`
+
+### 128K context / 96K max output
+
+- `glm_4_5()`
+- `glm_4_5_air()`
+- `glm_4_5_x()`
+- `glm_4_5_airx()`
+- `glm_4_5_flash()`
+
+### 128K context / 16K max output
+
+- `glm_4_32b_0414_128k()`
+
+## Request Semantics
+
+z.ai request building (`src/providers/zai.rs`) does the following:
+
+- Always sends `stream: true`
+- Always sends `stream_options.include_usage: true`
+- Uses OpenAI-like message conversion with z.ai replay shape:
+  - assistant content as plain string
+  - assistant thinking emitted via `reasoning_content` in message payload
+- `max_tokens` precedence:
+  1. `options.zai.max_tokens`
+  2. `options.max_tokens`
+
+### Forwarded z.ai option fields
+
+From `OpenAICompletionsOptions.zai`:
+
+- `do_sample`
+- `top_p`
+- `stop`
+- `tool_stream`
+- `request_id`
+- `user_id`
+- `response_format`
+- `thinking`
+
+If `model.reasoning == true` and no explicit `thinking` option is provided, Alchemy sets:
+
+```json
+{"thinking":{"type":"enabled"}}
+```
+
+## Streaming Semantics (Unified Output Layer)
+
+For each stream chunk, the z.ai provider maps to the shared event contract:
+
+- `delta.content` -> text events
+- reasoning fields -> thinking events (priority order):
+  1. `reasoning_content`
+  2. `reasoning`
+  3. `reasoning_text`
+- `delta.tool_calls` -> tool-call start/args/end events
+
+Stop reason mapping:
+
+- `"sensitive"` -> `StopReason::Error`
+- `"network_error"` -> `StopReason::Error`
+- other values use shared OpenAI-like stop mapping (`stop`, `length`, `tool_calls`, etc.)
+
+## Quick Start
+
+```rust
+use alchemy_llm::{glm_4_7, stream, OpenAICompletionsOptions};
+use alchemy_llm::types::{
+    AssistantMessageEvent, Context, Message, UserContent, UserMessage, ZaiChatCompletionsOptions,
+};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> alchemy_llm::Result<()> {
+    let model = glm_4_7();
+
+    let context = Context {
+        system_prompt: Some("You are concise.".to_string()),
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text("Explain ownership in two sentences.".to_string()),
+            timestamp: 0,
+        })],
+        tools: None,
+    };
+
+    let options = Some(OpenAICompletionsOptions {
+        api_key: std::env::var("ZAI_API_KEY").ok(),
+        max_tokens: Some(512),
+        zai: Some(ZaiChatCompletionsOptions::default()),
+        ..OpenAICompletionsOptions::default()
+    });
+
+    let mut events = stream(&model, &context, options)?;
+
+    while let Some(event) = events.next().await {
+        match event {
+            AssistantMessageEvent::ThinkingDelta { delta, .. } => print!("{delta}"),
+            AssistantMessageEvent::TextDelta { delta, .. } => print!("{delta}"),
+            AssistantMessageEvent::Done { message, .. } => {
+                println!("\nstop_reason: {:?}", message.stop_reason);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+```
+
+## Run Live Examples
+
+```bash
+cargo run --example zai_glm_simple_chat
+cargo run --example zai_glm_tool_call_smoke
+```


### PR DESCRIPTION
## Summary\n- update README provider/release/examples sections for PR #37\n- add new z.ai provider guide at docs/providers/zai.md\n- update docs index and API surface docs for z.ai constructors and provider paths\n- add Unreleased changelog entries for z.ai integration + ast-grep architecture rules\n\n## Validation\n- cargo check --all-targets --all-features\n- make ast-rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-class z.ai GLM provider integration with support for multiple GLM model variants.
  * Added new live examples demonstrating z.ai GLM chat and tool calling capabilities.

* **Documentation**
  * Added comprehensive z.ai provider guide with setup, configuration, and usage instructions.
  * Updated README with z.ai provider support and examples reference.

* **Chores**
  * Bumped release version to 0.1.6.
  * Enhanced architecture boundary checks with automated tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->