### PR TITLE
feat: add Featherless as a first-class shared provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ ANTHROPIC_OAUTH_TOKEN=xxxxx
 # OpenAI (GPT-4, etc.)
 OPENAI_API_KEY=sk-xxxxx
 
+# Featherless (OpenAI-compatible catalog provider)
+FEATHERLESS_API_KEY=rc_xxxxx
+
 # Google (Gemini)
 GEMINI_API_KEY=xxxxx
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/alchemy-llm/badge.svg)](https://docs.rs/alchemy-llm)
 [![License: MIT](https://img.shields.io/crates/l/alchemy-llm.svg)](https://opensource.org/licenses/MIT)
 
-A unified LLM API abstraction layer in Rust that supports 10+ providers through a consistent interface.
+A unified LLM API abstraction layer in Rust that supports 13+ providers through a consistent interface.
 
 > **Warning:** This project is in early development (v0.1.x). APIs may change without notice. Not recommended for production use yet.
 
@@ -16,6 +16,7 @@ A unified LLM API abstraction layer in Rust that supports 10+ providers through 
 
 - **Anthropic** (Claude)
 - **OpenAI** (GPT-4, GPT-3.5)
+- **Featherless** (OpenAI-compatible catalog provider)
 - **Google** (Gemini)
 - **AWS Bedrock**
 - **Mistral**
@@ -27,7 +28,7 @@ A unified LLM API abstraction layer in Rust that supports 10+ providers through 
 - **OpenRouter**
 - **z.ai** (GLM)
 
-> Current first-class streaming implementations in Rust: **OpenAI-compatible Completions** (including **OpenRouter**), **MiniMax Completions**, and **z.ai GLM Completions**. Other provider APIs are being ported incrementally.
+> Current first-class streaming implementations in Rust: **OpenAI-compatible Completions** (including **OpenAI**, **OpenRouter**, and **Featherless**), **MiniMax Completions**, and **z.ai GLM Completions**. Other provider APIs are being ported incrementally.
 
 ## Features
 
@@ -103,6 +104,33 @@ async fn main() -> alchemy_llm::Result<()> {
 }
 ```
 
+### Featherless Quick Example
+
+Featherless is exposed as a first-class provider in the same abstraction layer while reusing the shared OpenAI-compatible runtime underneath.
+
+```rust
+use alchemy_llm::{featherless_model, stream};
+use alchemy_llm::types::{Context, Message, UserContent, UserMessage};
+
+#[tokio::main]
+async fn main() -> alchemy_llm::Result<()> {
+    let model = featherless_model("moonshotai/Kimi-K2.5");
+    let context = Context {
+        system_prompt: None,
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text("Hello from Featherless".to_string()),
+            timestamp: 0,
+        })],
+        tools: None,
+    };
+
+    let _stream = stream(&model, &context, None)?;
+    Ok(())
+}
+```
+
+Set `FEATHERLESS_API_KEY` in your environment. If you have model-specific limits from `GET /v1/models`, you can override the returned model metadata before calling `stream(...)`.
+
 ## Latest Release
 
 - **Crate:** [alchemy-llm on crates.io](https://crates.io/crates/alchemy-llm)
@@ -159,6 +187,7 @@ async fn main() -> alchemy_llm::Result<()> {
 
 - [docs/README.md](./docs/README.md) - Documentation index
 - [docs/providers/architecture.md](./docs/providers/architecture.md) - Provider architecture contract for unified thinking, replay fidelity, and stream normalization
+- [docs/providers/featherless.md](./docs/providers/featherless.md) - Featherless as a first-class provider on the shared OpenAI-compatible path
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ read_when:
 ## Start Here
 
 - [providers/architecture.md](./providers/architecture.md) - Provider implementation contract for unified thinking, replay fidelity, and stream normalization
+- [providers/featherless.md](./providers/featherless.md) - Featherless first-class provider notes for the shared OpenAI-compatible path
 
 ## Notes
 

--- a/docs/providers/featherless.md
+++ b/docs/providers/featherless.md
@@ -1,0 +1,97 @@
+---
+summary: "Featherless first-class provider notes for the shared OpenAI-compatible runtime"
+read_when:
+  - You are adding or debugging Featherless support
+  - You need the Featherless model helper or environment variable name
+  - You want to understand how Featherless fits the unified abstraction
+---
+
+# Featherless Provider
+
+Featherless is a **first-class provider identity** in `alchemy_llm` that runs on the crate's shared `OpenAICompletions` runtime.
+
+That means:
+
+- the public abstraction stays the same: `Model<TApi>`, `stream(...)`, and `complete(...)`
+- callers can target `KnownProvider::Featherless` directly
+- the implementation reuses the shared OpenAI-compatible request/stream path underneath
+
+## Constructor
+
+Use the generic model helper:
+
+```rust
+use alchemy_llm::featherless_model;
+
+let model = featherless_model("moonshotai/Kimi-K2.5");
+```
+
+The helper returns `Model<OpenAICompletions>` with:
+
+- provider: `KnownProvider::Featherless`
+- base URL: `https://api.featherless.ai/v1/chat/completions`
+- default input type: text
+
+Because Featherless exposes a large dynamic catalog, the helper accepts the model id directly instead of providing one function per catalog entry.
+
+## Authentication
+
+Set:
+
+```bash
+FEATHERLESS_API_KEY=rc_...
+```
+
+Top-level `stream(...)` and `complete(...)` resolve that key through the normal provider environment lookup.
+
+## Unified Runtime Behavior
+
+Featherless is routed through the shared OpenAI-compatible runtime rather than a dedicated Featherless-only runtime.
+
+Current compatibility defaults are:
+
+- request path stays on `Api::OpenAICompletions`
+- `max_tokens` is used by default for output-token limits
+- `stream_options.include_usage` remains enabled
+- `store: false` remains enabled
+- developer-role system prompts remain enabled
+- reasoning-effort remains enabled when the model is marked as reasoning-capable
+
+## Live Validation Notes
+
+The following behaviors were validated against the live Featherless API during implementation:
+
+- chat completions succeeded at `POST /v1/chat/completions`
+- `max_tokens` was accepted
+- `max_completion_tokens` was also accepted, but the runtime defaults to `max_tokens`
+- `store: false` was accepted
+- `role: "developer"` messages were accepted
+- streaming SSE with `stream_options.include_usage` produced a final usage chunk
+- some models emit a `reasoning` field alongside normal assistant `content`
+- at least one model returned assistant `content` with leading whitespace; the crate preserves provider output as-is and does not trim it
+
+## Model-Dependent Capabilities
+
+Featherless is a catalog provider, so some capabilities vary by model family.
+
+In particular:
+
+- tool use may be model-dependent
+- context length and max completion limits vary by model
+- reasoning availability varies by model
+
+If you need exact limits, fetch the Featherless model catalog and override the returned `Model` metadata accordingly.
+
+## Headers
+
+If you need provider-specific headers, use the existing extension points:
+
+- `Model.headers`
+- `OpenAICompletionsOptions.headers`
+
+No Featherless-specific public abstraction is required for this.
+
+## Related Docs
+
+- [architecture.md](./architecture.md)
+- [../README.md](../README.md)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ pub(crate) mod test_helpers;
 
 pub use error::{Error, Result};
 pub use models::{
-    glm_4_32b_0414_128k, glm_4_5, glm_4_5_air, glm_4_5_airx, glm_4_5_flash, glm_4_5_x, glm_4_6,
-    glm_4_7, glm_4_7_flash, glm_4_7_flashx, glm_5, minimax_cn_m2, minimax_cn_m2_1,
-    minimax_cn_m2_1_highspeed, minimax_cn_m2_5, minimax_cn_m2_5_highspeed, minimax_m2,
-    minimax_m2_1, minimax_m2_1_highspeed, minimax_m2_5, minimax_m2_5_highspeed,
+    featherless_model, glm_4_32b_0414_128k, glm_4_5, glm_4_5_air, glm_4_5_airx, glm_4_5_flash,
+    glm_4_5_x, glm_4_6, glm_4_7, glm_4_7_flash, glm_4_7_flashx, glm_5, minimax_cn_m2,
+    minimax_cn_m2_1, minimax_cn_m2_1_highspeed, minimax_cn_m2_5, minimax_cn_m2_5_highspeed,
+    minimax_m2, minimax_m2_1, minimax_m2_1_highspeed, minimax_m2_5, minimax_m2_5_highspeed,
 };
 pub use providers::{
     get_env_api_key, stream_minimax_completions, stream_openai_completions,

--- a/src/models/featherless.rs
+++ b/src/models/featherless.rs
@@ -1,0 +1,59 @@
+use crate::types::{InputType, KnownProvider, Model, ModelCost, OpenAICompletions, Provider};
+
+const FEATHERLESS_BASE_URL: &str = "https://api.featherless.ai/v1/chat/completions";
+const DEFAULT_CONTEXT_WINDOW: u32 = 128_000;
+const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 16_384;
+const ZERO_MODEL_COST: ModelCost = ModelCost {
+    input: 0.0,
+    output: 0.0,
+    cache_read: 0.0,
+    cache_write: 0.0,
+};
+
+/// Build a first-class Featherless model on the shared OpenAI-compatible path.
+///
+/// Featherless exposes a large dynamic model catalog, so this constructor accepts
+/// the model identifier directly instead of curating one helper per model.
+/// Callers may override metadata fields on the returned model if they have more
+/// precise limits from `/v1/models`.
+pub fn featherless_model(id: impl Into<String>) -> Model<OpenAICompletions> {
+    let id = id.into();
+
+    Model {
+        name: id.clone(),
+        id,
+        api: OpenAICompletions,
+        provider: Provider::Known(KnownProvider::Featherless),
+        base_url: FEATHERLESS_BASE_URL.to_string(),
+        reasoning: false,
+        input: vec![InputType::Text],
+        cost: ZERO_MODEL_COST,
+        context_window: DEFAULT_CONTEXT_WINDOW,
+        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        headers: None,
+        compat: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{featherless_model, FEATHERLESS_BASE_URL};
+    use crate::types::{Api, ApiType, InputType, KnownProvider, Provider};
+
+    #[test]
+    fn featherless_model_uses_first_class_openai_compatible_path() {
+        let model = featherless_model("moonshotai/Kimi-K2.5");
+
+        assert_eq!(model.id, "moonshotai/Kimi-K2.5");
+        assert_eq!(model.name, "moonshotai/Kimi-K2.5");
+        assert_eq!(model.api.api(), Api::OpenAICompletions);
+        assert_eq!(model.provider, Provider::Known(KnownProvider::Featherless));
+        assert_eq!(model.base_url, FEATHERLESS_BASE_URL);
+        assert!(!model.reasoning);
+        assert_eq!(model.input, vec![InputType::Text]);
+        assert_eq!(model.context_window, 128_000);
+        assert_eq!(model.max_tokens, 16_384);
+        assert!(model.headers.is_none());
+        assert!(model.compat.is_none());
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,8 @@
+pub mod featherless;
 pub mod minimax;
 pub mod zai;
 
+pub use featherless::featherless_model;
 pub use minimax::{
     minimax_cn_m2, minimax_cn_m2_1, minimax_cn_m2_1_highspeed, minimax_cn_m2_5,
     minimax_cn_m2_5_highspeed, minimax_m2, minimax_m2_1, minimax_m2_1_highspeed, minimax_m2_5,

--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -30,6 +30,7 @@ fn get_env_api_key_for_known(provider: &KnownProvider) -> Option<String> {
 
         // Standard API key providers
         KnownProvider::OpenAI => env::var("OPENAI_API_KEY").ok(),
+        KnownProvider::Featherless => env::var("FEATHERLESS_API_KEY").ok(),
         KnownProvider::Google => env::var("GEMINI_API_KEY").ok(),
         KnownProvider::Groq => env::var("GROQ_API_KEY").ok(),
         KnownProvider::Cerebras => env::var("CEREBRAS_API_KEY").ok(),
@@ -128,6 +129,16 @@ mod tests {
         let result = get_env_api_key(&Provider::Known(KnownProvider::OpenAI));
         assert_eq!(result, Some(key.to_string()));
         env::remove_var("OPENAI_API_KEY");
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_env_api_key_featherless() {
+        let key = "fake_featherless_test_key";
+        env::set_var("FEATHERLESS_API_KEY", key);
+        let result = get_env_api_key(&Provider::Known(KnownProvider::Featherless));
+        assert_eq!(result, Some(key.to_string()));
+        env::remove_var("FEATHERLESS_API_KEY");
     }
 
     #[test]

--- a/src/providers/openai_completions.rs
+++ b/src/providers/openai_completions.rs
@@ -297,6 +297,9 @@ fn detect_compat(model: &Model<OpenAICompletions>) -> ResolvedCompat {
     let provider = &model.provider;
     let base_url = &model.base_url;
 
+    let is_featherless = matches!(provider, Provider::Known(KnownProvider::Featherless))
+        || base_url.contains("featherless.ai");
+
     let is_non_standard = matches!(
         provider,
         Provider::Known(KnownProvider::Cerebras)
@@ -307,7 +310,8 @@ fn detect_compat(model: &Model<OpenAICompletions>) -> ResolvedCompat {
         || base_url.contains("mistral.ai")
         || base_url.contains("chutes.ai");
 
-    let use_max_tokens = matches!(provider, Provider::Known(KnownProvider::Mistral))
+    let use_max_tokens = is_featherless
+        || matches!(provider, Provider::Known(KnownProvider::Mistral))
         || base_url.contains("mistral.ai")
         || base_url.contains("chutes.ai");
 
@@ -358,7 +362,15 @@ struct StreamDelta {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{InputType, ModelCost};
+    use crate::test_helpers::{
+        assert_streaming_final_message_shape, build_final_message_shape_sse_body,
+        ExpectedFinalMessageShape,
+    };
+    use crate::types::{
+        Context, InputType, MaxTokensField, Message, ModelCost, StopReason, UserContent,
+        UserMessage,
+    };
+    use serde_json::json;
 
     fn make_test_model(
         id: &str,
@@ -419,5 +431,89 @@ mod tests {
         assert_eq!(compat.max_tokens_field, MaxTokensField::MaxTokens);
         assert!(compat.requires_mistral_tool_ids);
         assert!(compat.requires_tool_result_name);
+    }
+
+    #[test]
+    fn detect_compat_for_featherless_defaults() {
+        let model = make_test_model(
+            "moonshotai/Kimi-K2.5",
+            "Kimi K2.5",
+            KnownProvider::Featherless,
+            "https://api.featherless.ai/v1/chat/completions",
+        );
+
+        let compat = detect_compat(&model);
+        assert!(compat.supports_store);
+        assert!(compat.supports_developer_role);
+        assert!(compat.supports_reasoning_effort);
+        assert!(compat.supports_usage_in_streaming);
+        assert_eq!(compat.max_tokens_field, MaxTokensField::MaxTokens);
+        assert!(!compat.requires_mistral_tool_ids);
+    }
+
+    #[test]
+    fn build_params_uses_max_tokens_for_featherless() {
+        let model = make_test_model(
+            "moonshotai/Kimi-K2.5",
+            "Kimi K2.5",
+            KnownProvider::Featherless,
+            "https://api.featherless.ai/v1/chat/completions",
+        );
+        let context = Context {
+            system_prompt: Some("Be concise.".to_string()),
+            messages: vec![Message::User(UserMessage {
+                content: UserContent::Text("Reply with ok".to_string()),
+                timestamp: 0,
+            })],
+            tools: None,
+        };
+        let options = OpenAICompletionsOptions {
+            max_tokens: Some(128),
+            ..OpenAICompletionsOptions::default()
+        };
+
+        let params = build_params(&model, &context, &options, &resolve_compat(&model));
+
+        assert_eq!(params["model"], json!("moonshotai/Kimi-K2.5"));
+        assert_eq!(params["max_tokens"], json!(128));
+        assert!(params.get("max_completion_tokens").is_none());
+        assert_eq!(params["store"], json!(false));
+        assert_eq!(params["stream_options"]["include_usage"], json!(true));
+        assert_eq!(params["messages"][0]["role"], json!("system"));
+    }
+
+    #[tokio::test]
+    async fn stream_featherless_openai_compatible_runtime_returns_expected_message_shape() {
+        let model = make_test_model(
+            "moonshotai/Kimi-K2.5",
+            "Kimi K2.5",
+            KnownProvider::Featherless,
+            "https://api.featherless.ai/v1/chat/completions",
+        );
+        let context = Context::default();
+        let options = OpenAICompletionsOptions {
+            api_key: Some("test-key".to_string()),
+            ..OpenAICompletionsOptions::default()
+        };
+        let sse_body = build_final_message_shape_sse_body(json!({
+            "reasoning": "thinking"
+        }));
+
+        assert_streaming_final_message_shape(
+            model,
+            context,
+            options,
+            sse_body,
+            "/v1/chat/completions",
+            stream_openai_completions,
+            ExpectedFinalMessageShape {
+                api: Api::OpenAICompletions,
+                provider: Provider::Known(KnownProvider::Featherless),
+                model: "moonshotai/Kimi-K2.5",
+                stop_reason: StopReason::Stop,
+                total_tokens: 15,
+            },
+        )
+        .await;
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -165,6 +165,28 @@ mod tests {
         }
     }
 
+    fn featherless_test_model(base_url: &str) -> Model<OpenAICompletions> {
+        Model {
+            id: "moonshotai/Kimi-K2.5".to_string(),
+            name: "Kimi K2.5".to_string(),
+            api: OpenAICompletions,
+            provider: Provider::Known(KnownProvider::Featherless),
+            base_url: base_url.to_string(),
+            reasoning: false,
+            input: vec![InputType::Text],
+            cost: ModelCost {
+                input: 0.0,
+                output: 0.0,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            },
+            context_window: 128_000,
+            max_tokens: 16_384,
+            headers: None,
+            compat: None,
+        }
+    }
+
     async fn assert_dispatches_to_provider<TApi>(model: Model<TApi>, expected_api: Api)
     where
         TApi: crate::types::ApiType,
@@ -195,6 +217,12 @@ mod tests {
     async fn stream_dispatches_to_zai_provider() {
         let model = zai_test_model("http://127.0.0.1:1/api/paas/v4/chat/completions");
         assert_dispatches_to_provider(model, Api::ZaiCompletions).await;
+    }
+
+    #[tokio::test]
+    async fn stream_dispatches_featherless_through_openai_completions_provider() {
+        let model = featherless_test_model("http://127.0.0.1:1/v1/chat/completions");
+        assert_dispatches_to_provider(model, Api::OpenAICompletions).await;
     }
 
     #[test]

--- a/src/types/api.rs
+++ b/src/types/api.rs
@@ -64,6 +64,7 @@ impl_str_mapping!(
 pub enum KnownProvider {
     AmazonBedrock,
     Anthropic,
+    Featherless,
     Google,
     GoogleVertex,
     OpenAI,
@@ -84,6 +85,7 @@ impl_str_mapping!(
     {
         AmazonBedrock => "amazon-bedrock",
         Anthropic => "anthropic",
+        Featherless => "featherless",
         Google => "google",
         GoogleVertex => "google-vertex",
         OpenAI => "openai",
@@ -158,7 +160,7 @@ impl CompatibilityOptions for NoCompat {
 
 #[cfg(test)]
 mod tests {
-    use super::Api;
+    use super::{Api, KnownProvider};
     use std::str::FromStr;
 
     #[test]
@@ -173,5 +175,13 @@ mod tests {
         let parsed = Api::from_str("zai-completions").expect("valid zai API variant");
         assert_eq!(parsed, Api::ZaiCompletions);
         assert_eq!(parsed.to_string(), "zai-completions");
+    }
+
+    #[test]
+    fn featherless_provider_round_trip() {
+        let parsed =
+            KnownProvider::from_str("featherless").expect("valid featherless provider variant");
+        assert_eq!(parsed, KnownProvider::Featherless);
+        assert_eq!(parsed.to_string(), "featherless");
     }
 }


### PR DESCRIPTION
## Summary
- add `KnownProvider::Featherless` and `FEATHERLESS_API_KEY` env resolution
- add `featherless_model(...)` on the shared `OpenAICompletions` path
- encode Featherless compat in the shared OpenAI-compatible runtime
- add tests for provider identity, env lookup, constructor, dispatch, compat, and normalized message shape
- document Featherless as a first-class provider within the unified abstraction

## Validation
- `make quality-quick`
- `cargo test`
- live manual probe against Featherless verified the crate abstraction normalizes Kimi output into `Content::Thinking` + `Content::Text`

## Notes
- kept Featherless on the shared `OpenAICompletions` runtime; no new runtime/API variant added
- defaulted Featherless compat to `max_tokens` while preserving the shared OpenAI-like flow
- observed one live Kimi response with leading whitespace in `Content::Text`; documented as model output and preserved as-is

## Ticket coverage
- ar-dz22 — Featherless provider identity and env lookup
- ar-xz6c — first-class Featherless model constructor
- ar-56s4 — Featherless compat in shared OpenAICompletions runtime
- ar-3ams — tests for unified abstraction behavior
- ar-4r46 — documentation updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Featherless as a supported provider, increasing total provider count to 13+
  * Featherless is fully compatible with OpenAI-compatible streaming capabilities
  * Added Quick Start example with environment configuration via FEATHERLESS_API_KEY

* **Documentation**
  * Added comprehensive documentation for Featherless provider setup and usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->