### PR TITLE
implement google generative ai

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -1,0 +1,151 @@
+---
+summary: "Google Generative AI (Gemini) first-class provider with dedicated streaming runtime"
+read_when:
+  - You are adding or debugging Google/Gemini support
+  - You need the Gemini model helper or environment variable name
+  - You want to understand how Gemini reasoning and tool calling works
+  - You want to understand how Gemini fits the unified abstraction
+---
+
+# Google Generative AI Provider
+
+Google Generative AI (Gemini) is a **first-class provider identity** in `alchemy_llm` with a dedicated streaming runtime that handles Gemini's unique REST API format.
+
+That means:
+
+- the public abstraction stays the same: `Model<TApi>`, `stream(...)`, and `complete(...)`
+- callers target `KnownProvider::Google`
+- a dedicated runtime handles Gemini's `contents`/`parts` format, `systemInstruction`, `generationConfig`, and SSE streaming with `alt=sse`
+- shared block handling reuses the crate's canonical `CurrentBlock` state machine
+
+## Quick Start
+
+```rust
+use alchemy_llm::{gemini_2_5_flash, stream};
+use alchemy_llm::types::{AssistantMessageEvent, Context, Message, UserContent, UserMessage};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> alchemy_llm::Result<()> {
+    let model = gemini_2_5_flash();
+    let context = Context {
+        system_prompt: None,
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text("Hello from Gemini".to_string()),
+            timestamp: 0,
+        })],
+        tools: None,
+    };
+
+    let mut stream = stream(&model, &context, None)?;
+
+    while let Some(event) = stream.next().await {
+        match event {
+            AssistantMessageEvent::TextDelta { delta, .. } => print!("{}", delta),
+            AssistantMessageEvent::ThinkingDelta { delta, .. } => print!("[thinking: {}]", delta),
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+```
+
+Set `GEMINI_API_KEY` before calling `stream(...)` or `complete(...)`.
+
+## Constructors
+
+```rust
+use alchemy_llm::{gemini_2_5_pro, gemini_2_5_flash};
+
+let model = gemini_2_5_flash();
+```
+
+All helpers return `Model<GoogleGenerativeAi>` with:
+
+- provider: `KnownProvider::Google`
+- base URL: `https://generativelanguage.googleapis.com/v1beta`
+- reasoning: `true`
+- context window: `1_048_576`
+- max output tokens: `65_536`
+- input types: text, image
+
+## Authentication
+
+Set:
+
+```bash
+GEMINI_API_KEY=AIza...
+```
+
+The API key is passed as a query parameter (`?key=...`) per Google's REST API convention, not as a Bearer token header.
+
+## API Format
+
+Google Gemini uses a unique REST API that differs from both OpenAI and Anthropic:
+
+- **Endpoint**: `/v1beta/models/{model}:streamGenerateContent?alt=sse`
+- **Messages**: `contents` array with `role: "user" | "model"` and `parts` arrays
+- **System prompt**: `systemInstruction` object (not a message role)
+- **Generation config**: `generationConfig` object for `temperature`, `maxOutputTokens`, etc.
+- **Tools**: `functionDeclarations` format (not OpenAI's `tools` schema)
+- **Tool calls**: `functionCall` in parts; results sent as `functionResponse`
+- **Thinking**: `thinkingConfig` with `thinkingBudget` (Gemini 2.5+); thoughts arrive as parts with `thought: true`
+
+## Reasoning
+
+For reasoning-capable models, the runtime automatically sets:
+
+```json
+{
+  "thinkingConfig": { "thinkingBudget": 8192 }
+}
+```
+
+Thought parts arrive with `thought: true` and are emitted as `ThinkingStart/ThinkingDelta/ThinkingEnd` events. The `thinking_signature` is set to `"google_thought"`.
+
+## Tool Calling
+
+Tools are converted to Google's `functionDeclarations` format:
+
+```json
+{
+  "tools": [{
+    "functionDeclarations": [{
+      "name": "get_weather",
+      "description": "Get weather",
+      "parameters": { "type": "object", ... }
+    }]
+  }]
+}
+```
+
+Tool calls arrive as `functionCall` parts and are mapped to `ToolCallStart/ToolCallDelta/ToolCallEnd` events. Tool results are sent back as `functionResponse` parts in user messages.
+
+## Stream Event Mapping
+
+| Gemini Chunk | Canonical Event |
+|---|---|
+| `parts[].text` | `TextStart/TextDelta/TextEnd` |
+| `parts[].text` + `thought: true` | `ThinkingStart/ThinkingDelta/ThinkingEnd` |
+| `parts[].functionCall` | `ToolCallStart/ToolCallDelta/ToolCallEnd` |
+| `usageMetadata` | Accumulated into `Usage` |
+| `finishReason` | Mapped to `StopReason` |
+
+## Stop Reason Mapping
+
+- `STOP` -> `StopReason::Stop`
+- `MAX_TOKENS` -> `StopReason::Length`
+- `SAFETY` / `RECITATION` / `BLOCKLIST` / `PROHIBITED_CONTENT` / `SPII` -> `StopReason::Error`
+
+## Replay
+
+When replaying assistant messages, thinking content is preserved with `thought: true` flag on parts. Tool calls are re-serialized as `functionCall` parts.
+
+## Files to Reference
+
+- `src/models/google.rs` - Model helpers (Gemini 2.5 Pro, Gemini 2.5 Flash)
+- `src/providers/google.rs` - Thin provider entry point
+- `src/providers/shared/google_like.rs` - Streaming runtime
+- `src/providers/env.rs` - Environment variable lookup (`GEMINI_API_KEY`)
+- `src/stream/mod.rs` - Top-level dispatch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,12 @@ pub(crate) mod test_helpers;
 
 pub use error::{Error, Result};
 pub use models::{
-    claude_haiku_4_5, claude_opus_4_6, claude_sonnet_4_6, featherless_model, glm_4_32b_0414_128k,
-    glm_4_5, glm_4_5_air, glm_4_5_airx, glm_4_5_flash, glm_4_5_x, glm_4_6, glm_4_7, glm_4_7_flash,
-    glm_4_7_flashx, glm_5, kimi_k2_5, minimax_cn_m2, minimax_cn_m2_1, minimax_cn_m2_1_highspeed,
-    minimax_cn_m2_5, minimax_cn_m2_5_highspeed, minimax_cn_m2_7, minimax_cn_m2_7_highspeed,
-    minimax_m2, minimax_m2_1, minimax_m2_1_highspeed, minimax_m2_5, minimax_m2_5_highspeed,
-    minimax_m2_7, minimax_m2_7_highspeed,
+    claude_haiku_4_5, claude_opus_4_6, claude_sonnet_4_6, featherless_model, gemini_2_5_flash,
+    gemini_2_5_pro, glm_4_32b_0414_128k, glm_4_5, glm_4_5_air, glm_4_5_airx, glm_4_5_flash,
+    glm_4_5_x, glm_4_6, glm_4_7, glm_4_7_flash, glm_4_7_flashx, glm_5, kimi_k2_5, minimax_cn_m2,
+    minimax_cn_m2_1, minimax_cn_m2_1_highspeed, minimax_cn_m2_5, minimax_cn_m2_5_highspeed,
+    minimax_cn_m2_7, minimax_cn_m2_7_highspeed, minimax_m2, minimax_m2_1, minimax_m2_1_highspeed,
+    minimax_m2_5, minimax_m2_5_highspeed, minimax_m2_7, minimax_m2_7_highspeed,
 };
 pub use providers::{
     get_env_api_key, stream_anthropic_messages, stream_kimi_messages, stream_minimax_completions,

--- a/src/models/google.rs
+++ b/src/models/google.rs
@@ -1,0 +1,58 @@
+use crate::types::{GoogleGenerativeAi, InputType, KnownProvider, Model, ModelCost, Provider};
+
+const GOOGLE_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
+const GOOGLE_CONTEXT_WINDOW: u32 = 1_048_576;
+const GOOGLE_MAX_OUTPUT_TOKENS: u32 = 65_536;
+const ZERO_MODEL_COST: ModelCost = ModelCost {
+    input: 0.0,
+    output: 0.0,
+    cache_read: 0.0,
+    cache_write: 0.0,
+};
+
+fn build_google_model(id: &str, name: &str) -> Model<GoogleGenerativeAi> {
+    Model {
+        id: id.to_string(),
+        name: name.to_string(),
+        api: GoogleGenerativeAi,
+        provider: Provider::Known(KnownProvider::Google),
+        base_url: GOOGLE_BASE_URL.to_string(),
+        reasoning: true,
+        input: vec![InputType::Text, InputType::Image],
+        cost: ZERO_MODEL_COST,
+        context_window: GOOGLE_CONTEXT_WINDOW,
+        max_tokens: GOOGLE_MAX_OUTPUT_TOKENS,
+        headers: None,
+        compat: None,
+    }
+}
+
+pub fn gemini_2_5_pro() -> Model<GoogleGenerativeAi> {
+    build_google_model("gemini-2.5-pro", "Gemini 2.5 Pro")
+}
+
+pub fn gemini_2_5_flash() -> Model<GoogleGenerativeAi> {
+    build_google_model("gemini-2.5-flash", "Gemini 2.5 Flash")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Api, ApiType};
+
+    #[test]
+    fn gemini_model_has_google_api() {
+        let model = gemini_2_5_pro();
+        assert_eq!(model.api.api(), Api::GoogleGenerativeAi);
+        assert_eq!(model.provider, Provider::Known(KnownProvider::Google));
+        assert_eq!(model.base_url, GOOGLE_BASE_URL);
+        assert!(model.reasoning);
+    }
+
+    #[test]
+    fn gemini_flash_model_supports_images() {
+        let model = gemini_2_5_flash();
+        assert!(model.input.contains(&InputType::Image));
+        assert!(model.reasoning);
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,11 +1,13 @@
 pub mod anthropic;
 pub mod featherless;
+pub mod google;
 pub mod kimi;
 pub mod minimax;
 pub mod zai;
 
 pub use anthropic::{claude_haiku_4_5, claude_opus_4_6, claude_sonnet_4_6};
 pub use featherless::featherless_model;
+pub use google::{gemini_2_5_flash, gemini_2_5_pro};
 pub use kimi::kimi_k2_5;
 pub use minimax::{
     minimax_cn_m2, minimax_cn_m2_1, minimax_cn_m2_1_highspeed, minimax_cn_m2_5,

--- a/src/providers/google.rs
+++ b/src/providers/google.rs
@@ -1,0 +1,147 @@
+use super::openai_completions::OpenAICompletionsOptions;
+use super::shared::stream_google_like;
+use crate::types::{AssistantMessageEventStream, Context, GoogleGenerativeAi, Model};
+
+pub fn stream_google_generative_ai(
+    model: &Model<GoogleGenerativeAi>,
+    context: &Context,
+    options: OpenAICompletionsOptions,
+) -> AssistantMessageEventStream {
+    stream_google_like(model, context, options)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::google::gemini_2_5_flash;
+    use crate::types::{
+        Api, AssistantMessageEvent, Content, KnownProvider, Message, Provider, StopReason, Tool,
+        UserContent, UserMessage,
+    };
+    use futures::StreamExt;
+    use std::env;
+
+    fn require_live_api_key() {
+        assert!(
+            env::var("GEMINI_API_KEY").is_ok(),
+            "GEMINI_API_KEY must be set to run live Google tests"
+        );
+    }
+
+    fn text_context(prompt: &str) -> Context {
+        Context {
+            system_prompt: Some("You are concise.".to_string()),
+            messages: vec![Message::User(UserMessage {
+                content: UserContent::Text(prompt.to_string()),
+                timestamp: 0,
+            })],
+            tools: None,
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "live API test"]
+    async fn live_google_complete_returns_typed_text_message() {
+        require_live_api_key();
+
+        let model = gemini_2_5_flash();
+        let result = crate::complete(
+            &model,
+            &text_context("Reply with exactly: hello from gemini"),
+            Some(OpenAICompletionsOptions {
+                max_tokens: Some(64),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("google complete should succeed");
+
+        assert_eq!(result.api, Api::GoogleGenerativeAi);
+        assert_eq!(result.provider, Provider::Known(KnownProvider::Google));
+        assert!(matches!(
+            result.stop_reason,
+            StopReason::Stop | StopReason::Length
+        ));
+        assert!(matches!(result.content.first(), Some(Content::Text { .. })));
+    }
+
+    #[tokio::test]
+    #[ignore = "live API test"]
+    async fn live_google_stream_emits_typed_text_events() {
+        require_live_api_key();
+
+        let model = gemini_2_5_flash();
+        let mut stream = crate::stream(
+            &model,
+            &text_context("Say hello in one short sentence."),
+            Some(OpenAICompletionsOptions {
+                max_tokens: Some(64),
+                ..Default::default()
+            }),
+        )
+        .expect("google stream should start");
+
+        let events: Vec<_> = stream.by_ref().collect().await;
+
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AssistantMessageEvent::Start { partial }
+                if partial.provider == Provider::Known(KnownProvider::Google)
+                    && partial.api == Api::GoogleGenerativeAi
+        )));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::TextDelta { .. })));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AssistantMessageEvent::Done { message, .. }
+                if message.provider == Provider::Known(KnownProvider::Google)
+        )));
+    }
+
+    #[tokio::test]
+    #[ignore = "live API test"]
+    async fn live_google_complete_returns_typed_tool_call() {
+        require_live_api_key();
+
+        let model = gemini_2_5_flash();
+        let context = Context {
+            system_prompt: None,
+            messages: vec![Message::User(UserMessage {
+                content: UserContent::Text(
+                    "Use the get_weather tool for Austin, TX. Do not answer directly.".to_string(),
+                ),
+                timestamp: 0,
+            })],
+            tools: Some(vec![Tool::new(
+                "get_weather",
+                "Get the weather for a city",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"}
+                    },
+                    "required": ["city"]
+                }),
+            )]),
+        };
+
+        let result = crate::complete(
+            &model,
+            &context,
+            Some(OpenAICompletionsOptions {
+                max_tokens: Some(256),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("google tool call should succeed");
+
+        assert_eq!(result.api, Api::GoogleGenerativeAi);
+        assert_eq!(result.stop_reason, StopReason::ToolUse);
+        assert!(matches!(
+            result.content.first(),
+            Some(Content::ToolCall { inner }) if inner.name == "get_weather"
+        ));
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod env;
+pub mod google;
 pub mod kimi;
 pub mod minimax;
 pub mod openai_completions;
@@ -8,6 +9,7 @@ pub mod zai;
 
 pub use anthropic::stream_anthropic_messages;
 pub use env::get_env_api_key;
+pub use google::stream_google_generative_ai;
 pub use kimi::stream_kimi_messages;
 pub use minimax::stream_minimax_completions;
 pub use openai_completions::{stream_openai_completions, OpenAICompletionsOptions};

--- a/src/providers/shared/google_like.rs
+++ b/src/providers/shared/google_like.rs
@@ -1,0 +1,579 @@
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+use serde::Deserialize;
+use serde_json::json;
+
+use super::openai_like_runtime::{process_sse_stream, send_streaming_request};
+use super::{
+    finish_current_block, handle_reasoning_delta, handle_text_delta, handle_tool_calls,
+    initialize_output, merge_headers, push_stream_done, push_stream_error, CurrentBlock,
+    OpenAiLikeFunctionDelta, OpenAiLikeToolCallDelta, ReasoningDelta,
+};
+use crate::types::{
+    Api, AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream, Content, Context,
+    EventStreamSender, GoogleGenerativeAi, InputType, Message, Model, StopReason, Tool,
+    ToolResultContent, Usage, UserContent, UserContentBlock,
+};
+
+const THINKING_SIGNATURE: &str = "google_thought";
+
+pub(crate) fn stream_google_like(
+    model: &Model<GoogleGenerativeAi>,
+    context: &Context,
+    options: crate::providers::OpenAICompletionsOptions,
+) -> AssistantMessageEventStream {
+    let (stream, sender) = AssistantMessageEventStream::new();
+    let model = model.clone();
+    let context = context.clone();
+    tokio::spawn(async move { run_stream(model, context, options, sender).await });
+    stream
+}
+
+async fn run_stream(
+    model: Model<GoogleGenerativeAi>,
+    context: Context,
+    options: crate::providers::OpenAICompletionsOptions,
+    mut sender: EventStreamSender,
+) {
+    let mut output = initialize_output(
+        Api::GoogleGenerativeAi,
+        model.provider.clone(),
+        model.id.clone(),
+    );
+    if let Err(e) = run_stream_inner(&model, &context, &options, &mut output, &mut sender).await {
+        push_stream_error(&mut output, &mut sender, e);
+    }
+}
+
+async fn run_stream_inner(
+    model: &Model<GoogleGenerativeAi>,
+    context: &Context,
+    options: &crate::providers::OpenAICompletionsOptions,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+) -> Result<(), crate::Error> {
+    let api_key = options
+        .api_key
+        .as_ref()
+        .ok_or_else(|| crate::Error::NoApiKey(model.provider.to_string()))?;
+
+    let url = format!(
+        "{}/models/{}:streamGenerateContent?alt=sse&key={}",
+        model.base_url, model.id, api_key
+    );
+    let client = build_client(model, options)?;
+    let params = build_params(model, context, options);
+    let response = send_streaming_request(&client, &url, &params).await?;
+
+    sender.push(AssistantMessageEvent::Start {
+        partial: output.clone(),
+    });
+
+    let mut current_block: Option<CurrentBlock> = None;
+
+    process_sse_stream::<StreamChunk, _>(response, |chunk| {
+        process_chunk(&chunk, output, sender, &mut current_block);
+    })
+    .await?;
+
+    finish_current_block(&mut current_block, output, sender);
+    push_stream_done(output, sender);
+    Ok(())
+}
+
+fn build_client(
+    model: &Model<GoogleGenerativeAi>,
+    options: &crate::providers::OpenAICompletionsOptions,
+) -> Result<reqwest::Client, crate::Error> {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    merge_headers(&mut headers, model.headers.as_ref());
+    merge_headers(&mut headers, options.headers.as_ref());
+    reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .map_err(crate::Error::from)
+}
+
+pub(crate) fn build_params(
+    model: &Model<GoogleGenerativeAi>,
+    context: &Context,
+    options: &crate::providers::OpenAICompletionsOptions,
+) -> serde_json::Value {
+    let mut params = json!({ "contents": convert_contents(model, context) });
+
+    if let Some(sys) = &context.system_prompt {
+        params["systemInstruction"] = json!({ "parts": [{ "text": sys }] });
+    }
+
+    let mut gen_config = serde_json::Map::new();
+    if let Some(max) = options.max_tokens {
+        gen_config.insert("maxOutputTokens".into(), json!(max));
+    }
+    if let Some(t) = options.temperature {
+        gen_config.insert("temperature".into(), json!(t));
+    }
+    if !gen_config.is_empty() {
+        params["generationConfig"] = serde_json::Value::Object(gen_config);
+    }
+
+    if model.reasoning {
+        params["thinkingConfig"] = json!({ "thinkingBudget": 8192 });
+    }
+
+    if let Some(tools) = &context.tools {
+        params["tools"] = convert_tools(tools);
+    }
+
+    if let Some(tool_choice) = &options.tool_choice {
+        let v = serde_json::to_value(tool_choice).unwrap_or(json!("auto"));
+        let mode = match v.as_str().unwrap_or("auto") {
+            "none" => "NONE",
+            "required" => "ANY",
+            _ => "AUTO",
+        };
+        params["toolConfig"] = json!({ "functionCallingConfig": { "mode": mode } });
+    }
+
+    params
+}
+
+fn convert_contents(
+    model: &Model<GoogleGenerativeAi>,
+    context: &Context,
+) -> Vec<serde_json::Value> {
+    context
+        .messages
+        .iter()
+        .filter_map(|m| match m {
+            Message::User(u) => Some(json!({
+                "role": "user",
+                "parts": convert_user_parts(model, &u.content),
+            })),
+            Message::Assistant(a) => {
+                let parts = convert_assistant_parts(a);
+                (!parts.is_empty()).then(|| json!({ "role": "model", "parts": parts }))
+            }
+            Message::ToolResult(r) => {
+                let text = r
+                    .content
+                    .iter()
+                    .filter_map(|c| match c {
+                        ToolResultContent::Text(t) => Some(t.text.clone()),
+                        ToolResultContent::Image(_) => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Some(json!({
+                    "role": "user",
+                    "parts": [{ "functionResponse": {
+                        "name": r.tool_name,
+                        "response": { "result": text }
+                    }}]
+                }))
+            }
+        })
+        .collect()
+}
+
+fn convert_user_parts(
+    model: &Model<GoogleGenerativeAi>,
+    content: &UserContent,
+) -> Vec<serde_json::Value> {
+    match content {
+        UserContent::Text(text) => vec![json!({ "text": text })],
+        UserContent::Multi(blocks) => blocks
+            .iter()
+            .filter_map(|b| match b {
+                UserContentBlock::Text(t) => Some(json!({ "text": t.text })),
+                UserContentBlock::Image(img) if model.input.contains(&InputType::Image) => Some(
+                    json!({ "inlineData": { "mimeType": img.mime_type, "data": img.to_base64() } }),
+                ),
+                UserContentBlock::Image(_) => None,
+            })
+            .collect(),
+    }
+}
+
+fn convert_assistant_parts(assistant: &AssistantMessage) -> Vec<serde_json::Value> {
+    assistant
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::Thinking { inner } if !inner.thinking.is_empty() => {
+                Some(json!({ "thought": true, "text": inner.thinking }))
+            }
+            Content::Text { inner } if !inner.text.is_empty() => {
+                Some(json!({ "text": inner.text }))
+            }
+            Content::ToolCall { inner } => {
+                Some(json!({ "functionCall": { "name": inner.name, "args": inner.arguments } }))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn convert_tools(tools: &[Tool]) -> serde_json::Value {
+    let decls: Vec<_> = tools
+        .iter()
+        .map(|t| {
+            json!({
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters,
+            })
+        })
+        .collect();
+    json!([{ "functionDeclarations": decls }])
+}
+
+fn process_chunk(
+    chunk: &StreamChunk,
+    output: &mut AssistantMessage,
+    sender: &mut EventStreamSender,
+    current_block: &mut Option<CurrentBlock>,
+) {
+    if let Some(u) = &chunk.usage_metadata {
+        let input = u.prompt_token_count.unwrap_or(0);
+        let out = u.candidates_token_count.unwrap_or(0);
+        let thoughts = u.thoughts_token_count.unwrap_or(0);
+        output.usage = Usage {
+            input,
+            output: out,
+            cache_read: u.cached_content_token_count.unwrap_or(0),
+            cache_write: 0,
+            total_tokens: u.total_token_count.unwrap_or(input + out + thoughts),
+            cost: crate::types::Cost::default(),
+        };
+    }
+
+    let Some(candidate) = chunk.candidates.as_ref().and_then(|c| c.first()) else {
+        return;
+    };
+    if let Some(reason) = &candidate.finish_reason {
+        output.stop_reason = map_stop_reason(reason);
+    }
+
+    let Some(content) = &candidate.content else {
+        return;
+    };
+
+    for part in &content.parts {
+        if let Some(text) = &part.text {
+            if part.thought.unwrap_or(false) {
+                handle_reasoning_delta(
+                    ReasoningDelta {
+                        text,
+                        signature: THINKING_SIGNATURE,
+                    },
+                    output,
+                    sender,
+                    current_block,
+                );
+            } else {
+                handle_text_delta(text, output, sender, current_block);
+            }
+        }
+
+        if let Some(fc) = &part.function_call {
+            let args_str = fc
+                .args
+                .as_ref()
+                .map(|a| serde_json::to_string(a).unwrap_or_default())
+                .unwrap_or_default();
+            let tool_deltas = vec![OpenAiLikeToolCallDelta {
+                id: Some(format!("call_{}", fc.name)),
+                function: Some(OpenAiLikeFunctionDelta {
+                    name: Some(fc.name.clone()),
+                    arguments: Some(args_str),
+                }),
+            }];
+            handle_tool_calls(&tool_deltas, output, sender, current_block);
+            output.stop_reason = StopReason::ToolUse;
+        }
+    }
+}
+
+fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "STOP" => StopReason::Stop,
+        "MAX_TOKENS" => StopReason::Length,
+        "SAFETY" | "RECITATION" | "BLOCKLIST" | "PROHIBITED_CONTENT" | "SPII" => StopReason::Error,
+        _ => StopReason::Stop,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StreamChunk {
+    candidates: Option<Vec<Candidate>>,
+    usage_metadata: Option<UsageMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Candidate {
+    content: Option<CandidateContent>,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CandidateContent {
+    parts: Vec<Part>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Part {
+    text: Option<String>,
+    thought: Option<bool>,
+    function_call: Option<FunctionCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FunctionCall {
+    name: String,
+    args: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageMeta {
+    prompt_token_count: Option<u32>,
+    candidates_token_count: Option<u32>,
+    total_token_count: Option<u32>,
+    cached_content_token_count: Option<u32>,
+    thoughts_token_count: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::OpenAICompletionsOptions;
+    use crate::types::{
+        AssistantMessageEvent, KnownProvider, ModelCost, Provider, TextContent, ToolResultMessage,
+        UserMessage,
+    };
+    use futures::executor::block_on;
+    use futures::StreamExt;
+
+    fn make_model(reasoning: bool) -> Model<GoogleGenerativeAi> {
+        Model {
+            id: "gemini-2.5-flash".to_string(),
+            name: "Gemini 2.5 Flash".to_string(),
+            api: GoogleGenerativeAi,
+            provider: Provider::Known(KnownProvider::Google),
+            base_url: "https://generativelanguage.googleapis.com/v1beta".to_string(),
+            reasoning,
+            input: vec![InputType::Text, InputType::Image],
+            cost: ModelCost {
+                input: 0.0,
+                output: 0.0,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            },
+            context_window: 1_048_576,
+            max_tokens: 65_536,
+            headers: None,
+            compat: None,
+        }
+    }
+
+    fn make_context() -> Context {
+        Context {
+            system_prompt: Some("You are concise".to_string()),
+            messages: vec![Message::User(UserMessage {
+                content: UserContent::Text("Hello".to_string()),
+                timestamp: 0,
+            })],
+            tools: None,
+        }
+    }
+
+    fn make_output() -> AssistantMessage {
+        AssistantMessage {
+            content: vec![],
+            api: Api::GoogleGenerativeAi,
+            provider: Provider::Known(KnownProvider::Google),
+            model: "gemini-2.5-flash".to_string(),
+            usage: Usage::default(),
+            stop_reason: StopReason::Stop,
+            error_message: None,
+            timestamp: 0,
+        }
+    }
+
+    fn run_chunks(chunks: Vec<StreamChunk>) -> (Vec<AssistantMessageEvent>, AssistantMessage) {
+        let (mut stream, mut sender) = AssistantMessageEventStream::new();
+        let mut output = make_output();
+        let mut block = None;
+        for c in chunks {
+            process_chunk(&c, &mut output, &mut sender, &mut block);
+        }
+        finish_current_block(&mut block, &mut output, &mut sender);
+        drop(sender);
+        let events = block_on(async move { stream.by_ref().collect::<Vec<_>>().await });
+        (events, output)
+    }
+
+    #[test]
+    fn build_params_sets_system_instruction() {
+        let p = build_params(&make_model(true), &make_context(), &Default::default());
+        assert_eq!(
+            p["systemInstruction"]["parts"][0]["text"],
+            "You are concise"
+        );
+    }
+
+    #[test]
+    fn build_params_uses_user_role_and_parts() {
+        let p = build_params(&make_model(false), &make_context(), &Default::default());
+        assert_eq!(p["contents"][0]["role"], "user");
+        assert_eq!(p["contents"][0]["parts"][0]["text"], "Hello");
+    }
+
+    #[test]
+    fn build_params_adds_thinking_config_for_reasoning() {
+        let p = build_params(&make_model(true), &make_context(), &Default::default());
+        assert_eq!(p["thinkingConfig"]["thinkingBudget"], 8192);
+    }
+
+    #[test]
+    fn build_params_omits_thinking_config_for_non_reasoning() {
+        let p = build_params(&make_model(false), &make_context(), &Default::default());
+        assert!(p.get("thinkingConfig").is_none());
+    }
+
+    #[test]
+    fn build_params_includes_generation_config() {
+        let p = build_params(
+            &make_model(false),
+            &make_context(),
+            &OpenAICompletionsOptions {
+                temperature: Some(0.7),
+                max_tokens: Some(1024),
+                ..Default::default()
+            },
+        );
+        assert_eq!(p["generationConfig"]["temperature"], 0.7);
+        assert_eq!(p["generationConfig"]["maxOutputTokens"], 1024);
+    }
+
+    #[test]
+    fn build_params_replays_thinking_with_thought_flag() {
+        let assistant = AssistantMessage {
+            content: vec![Content::thinking("step"), Content::text("answer")],
+            ..make_output()
+        };
+        let ctx = Context {
+            system_prompt: None,
+            messages: vec![Message::Assistant(assistant)],
+            tools: None,
+        };
+        let p = build_params(&make_model(true), &ctx, &Default::default());
+        assert_eq!(p["contents"][0]["role"], "model");
+        assert_eq!(p["contents"][0]["parts"][0]["thought"], true);
+        assert_eq!(p["contents"][0]["parts"][0]["text"], "step");
+        assert_eq!(p["contents"][0]["parts"][1]["text"], "answer");
+    }
+
+    #[test]
+    fn build_params_converts_tool_result_to_function_response() {
+        let ctx = Context {
+            system_prompt: None,
+            messages: vec![Message::ToolResult(ToolResultMessage {
+                tool_call_id: "call_get_weather".into(),
+                tool_name: "get_weather".to_string(),
+                content: vec![ToolResultContent::Text(TextContent {
+                    text: "sunny".to_string(),
+                    text_signature: None,
+                })],
+                details: None,
+                is_error: false,
+                timestamp: 0,
+            })],
+            tools: None,
+        };
+        let p = build_params(&make_model(false), &ctx, &Default::default());
+        assert_eq!(
+            p["contents"][0]["parts"][0]["functionResponse"]["name"],
+            "get_weather"
+        );
+    }
+
+    #[test]
+    fn text_chunk_emits_text_events() {
+        let chunk: StreamChunk = serde_json::from_value(json!({
+            "candidates": [{ "content": { "parts": [{ "text": "hi" }], "role": "model" } }]
+        }))
+        .unwrap();
+        let (events, output) = run_chunks(vec![chunk]);
+        assert!(matches!(events[0], AssistantMessageEvent::TextStart { .. }));
+        assert!(matches!(&output.content[0], Content::Text { inner } if inner.text == "hi"));
+    }
+
+    #[test]
+    fn thought_chunk_emits_thinking_events() {
+        let chunk: StreamChunk = serde_json::from_value(json!({
+            "candidates": [{ "content": { "parts": [{ "text": "hmm", "thought": true }], "role": "model" } }]
+        }))
+        .unwrap();
+        let (events, output) = run_chunks(vec![chunk]);
+        assert!(matches!(
+            events[0],
+            AssistantMessageEvent::ThinkingStart { .. }
+        ));
+        assert!(
+            matches!(&output.content[0], Content::Thinking { inner } if inner.thinking == "hmm")
+        );
+    }
+
+    #[test]
+    fn function_call_chunk_emits_tool_call() {
+        let chunk: StreamChunk = serde_json::from_value(json!({
+            "candidates": [{ "content": { "parts": [{
+                "functionCall": { "name": "get_weather", "args": { "city": "Tokyo" } }
+            }], "role": "model" } }]
+        }))
+        .unwrap();
+        let (_events, output) = run_chunks(vec![chunk]);
+        assert_eq!(output.stop_reason, StopReason::ToolUse);
+        assert!(
+            matches!(&output.content[0], Content::ToolCall { inner } if inner.name == "get_weather")
+        );
+    }
+
+    #[test]
+    fn usage_metadata_updates_output() {
+        let chunk: StreamChunk = serde_json::from_value(json!({
+            "candidates": [{ "content": { "parts": [{ "text": "hi" }] }, "finishReason": "STOP" }],
+            "usageMetadata": { "promptTokenCount": 10, "candidatesTokenCount": 5, "totalTokenCount": 15 }
+        }))
+        .unwrap();
+        let (_, output) = run_chunks(vec![chunk]);
+        assert_eq!(output.usage.input, 10);
+        assert_eq!(output.usage.output, 5);
+        assert_eq!(output.usage.total_tokens, 15);
+    }
+
+    #[test]
+    fn stop_reasons_map_correctly() {
+        let mut output = make_output();
+        let mut sender = AssistantMessageEventStream::new().1;
+        let mut block = None;
+
+        let chunk: StreamChunk = serde_json::from_value(json!({
+            "candidates": [{ "content": { "parts": [{ "text": "x" }] }, "finishReason": "MAX_TOKENS" }]
+        }))
+        .unwrap();
+        process_chunk(&chunk, &mut output, &mut sender, &mut block);
+        assert_eq!(output.stop_reason, StopReason::Length);
+    }
+
+    #[test]
+    fn convert_tools_uses_function_declarations() {
+        let tools = vec![Tool::new("calc", "Calculate", json!({"type": "object"}))];
+        let result = convert_tools(&tools);
+        assert_eq!(result[0]["functionDeclarations"][0]["name"], "calc");
+    }
+}

--- a/src/providers/shared/mod.rs
+++ b/src/providers/shared/mod.rs
@@ -1,6 +1,7 @@
 //! Shared utilities for provider implementations.
 
 mod anthropic_like;
+mod google_like;
 mod http;
 mod openai_like_messages;
 mod openai_like_runtime;
@@ -10,6 +11,7 @@ mod timestamp;
 pub(crate) use anthropic_like::{
     stream_anthropic_like_messages, AnthropicLikeAuth, AnthropicLikeProviderConfig,
 };
+pub(crate) use google_like::stream_google_like;
 pub(crate) use http::merge_headers;
 pub(crate) use openai_like_messages::{
     convert_messages, convert_tools, AssistantThinkingMode, OpenAiLikeMessageOptions,
@@ -23,5 +25,5 @@ pub(crate) use stream_blocks::finish_current_block;
 pub(crate) use stream_blocks::{
     apply_deferred_tool_calls, handle_reasoning_delta, handle_text_delta, handle_tool_calls,
     map_stop_reason, prepare_openai_like_chunk, update_usage_from_chunk, CurrentBlock,
-    OpenAiLikeStreamChunk, OpenAiLikeToolCallDelta, ReasoningDelta,
+    OpenAiLikeFunctionDelta, OpenAiLikeStreamChunk, OpenAiLikeToolCallDelta, ReasoningDelta,
 };

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2,12 +2,13 @@ pub use crate::types::{AssistantMessageEventStream, EventStreamSender};
 
 use crate::error::{Error, Result};
 use crate::providers::{
-    get_env_api_key, stream_anthropic_messages, stream_kimi_messages, stream_minimax_completions,
-    stream_openai_completions, stream_zai_completions, OpenAICompletionsOptions,
+    get_env_api_key, stream_anthropic_messages, stream_google_generative_ai, stream_kimi_messages,
+    stream_minimax_completions, stream_openai_completions, stream_zai_completions,
+    OpenAICompletionsOptions,
 };
 use crate::types::{
-    AnthropicMessages, Api, AssistantMessage, Context, KnownProvider, MinimaxCompletions, Model,
-    OpenAICompletions, Provider, ZaiCompletions,
+    AnthropicMessages, Api, AssistantMessage, Context, GoogleGenerativeAi, KnownProvider,
+    MinimaxCompletions, Model, OpenAICompletions, Provider, ZaiCompletions,
 };
 
 /// Stream a completion from an OpenAI-compatible model.
@@ -99,9 +100,15 @@ where
         Api::OpenAIResponses => Err(Error::InvalidResponse(
             "OpenAI Responses provider not yet implemented".to_string(),
         )),
-        Api::GoogleGenerativeAi => Err(Error::InvalidResponse(
-            "Google Generative AI provider not yet implemented".to_string(),
-        )),
+        Api::GoogleGenerativeAi => {
+            let model_ptr = model as *const Model<TApi> as *const Model<GoogleGenerativeAi>;
+            let google_model = unsafe { &*model_ptr };
+            Ok(stream_google_generative_ai(
+                google_model,
+                context,
+                resolved_options,
+            ))
+        }
         Api::GoogleVertex => Err(Error::InvalidResponse(
             "Google Vertex provider not yet implemented".to_string(),
         )),
@@ -263,6 +270,34 @@ mod tests {
     async fn stream_dispatches_featherless_through_openai_completions_provider() {
         let model = featherless_test_model("http://127.0.0.1:1/v1/chat/completions");
         assert_dispatches_to_provider(model, Api::OpenAICompletions).await;
+    }
+
+    fn google_test_model(base_url: &str) -> Model<GoogleGenerativeAi> {
+        Model {
+            id: "gemini-2.5-flash".to_string(),
+            name: "Gemini 2.5 Flash".to_string(),
+            api: GoogleGenerativeAi,
+            provider: Provider::Known(KnownProvider::Google),
+            base_url: base_url.to_string(),
+            reasoning: true,
+            input: vec![InputType::Text],
+            cost: ModelCost {
+                input: 0.0,
+                output: 0.0,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            },
+            context_window: 1_048_576,
+            max_tokens: 65_536,
+            headers: None,
+            compat: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_dispatches_to_google_provider() {
+        let model = google_test_model("http://127.0.0.1:1");
+        assert_dispatches_to_provider(model, Api::GoogleGenerativeAi).await;
     }
 
     #[test]


### PR DESCRIPTION
## Description

  Dedicated Google Generative AI (Gemini) provider implementation following the shared runtime pattern established by Anthropic/Kimi
  and MiniMax/z.ai providers.

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Test coverage improvement

  ## Related Issues

  Fixes #28

  ## Changes Made

  - `src/providers/shared/google_like.rs` — streaming runtime handling Gemini's `contents`/`parts` format, `systemInstruction`,
  `generationConfig`, `thinkingConfig`, `functionDeclarations` tool schema, and `functionCall`/`functionResponse` tool use flow.
  Reuses shared `process_sse_stream`, `send_streaming_request`, `handle_reasoning_delta`, `handle_text_delta`, `handle_tool_calls`,
  and `CurrentBlock` state machine.
  - `src/providers/google.rs` — thin entry point delegating to `stream_google_like`
  - `src/models/google.rs` — model constructors for `gemini-2.5-pro` and `gemini-2.5-flash` (GA stable IDs)
  - Wired into `stream/mod.rs` dispatch, `providers/mod.rs`, `models/mod.rs`, `lib.rs`
  - `docs/providers/google.md` — provider guide

  ## Testing Done

  - [x] Ran `cargo test`
  - [x] Ran `cargo clippy`
  - [x] Ran `cargo fmt`
  - [x] Manual testing completed
  - [x] Added/updated tests

  ## Quality Gates

  - [x] Follows project coding guidelines (AGENTS.md)
  - [x] No new warnings from clippy
  - [x] All tests passing
  - [x] Documentation updated (if needed)
  - [ ] TypeScript behavior matched (for ports)

  ## Additional Context

  - Env var `GEMINI_API_KEY` was already mapped to `KnownProvider::Google` in `env.rs` — no change needed
  - `GoogleGenerativeAi` marker type and `Api::GoogleGenerativeAi` enum variant already existed — no change needed
  - Google authenticates via query parameter (`?key=...`) rather than Bearer header, so `build_client` omits the Authorization header
   while reusing `send_streaming_request` for error handling
  - Thinking is normalized via `handle_reasoning_delta` with signature `"google_thought"`; replay serializes thinking back with
  `"thought": true` on parts per Google's API contract
  - Aligned with `docs/providers/architecture.md` provider thinking contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Google Generative AI (Gemini) as a first-class provider with full streaming support
  * Introduced Gemini 2.5 Pro and Flash models with reasoning and tool-calling capabilities
  * Added image input support for Gemini models

* **Documentation**
  * Added comprehensive Google Generative AI provider documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->