### PR TITLE
Deduplicate OpenAI-like provider streaming pipeline into shared layer

### DIFF
--- a/src/providers/minimax.rs
+++ b/src/providers/minimax.rs
@@ -1,29 +1,22 @@
-use serde::Deserialize;
 use serde_json::json;
 
 use super::openai_completions::OpenAICompletionsOptions;
-#[cfg(test)]
-use super::shared::finish_current_block;
 use super::shared::{
-    apply_deferred_tool_calls, convert_messages, convert_tools, handle_reasoning_delta,
-    handle_text_delta, initialize_output, map_stop_reason, prepare_openai_like_chunk,
-    push_stream_error, run_openai_like_stream, AssistantThinkingMode, CurrentBlock,
-    OpenAiLikeMessageOptions, OpenAiLikeRequest, OpenAiLikeStreamChunk, OpenAiLikeToolCallDelta,
+    apply_deferred_tool_calls, convert_messages, convert_tools, extract_reasoning,
+    handle_reasoning_delta, handle_text_delta, map_stop_reason, prepare_openai_like_chunk,
+    run_openai_like_stream, spawn_openai_like_stream, AssistantThinkingMode, CurrentBlock,
+    OpenAiLikeMessageOptions, OpenAiLikeRequest, OpenAiLikeStreamChunk, OpenAiLikeStreamDelta,
     ReasoningDelta, SystemPromptRole,
 };
+#[cfg(test)]
+use super::shared::{finish_current_block, initialize_output};
 use crate::types::{
-    Api, AssistantMessage, AssistantMessageEventStream, Context, EventStreamSender,
-    MinimaxCompletions, Model,
+    AssistantMessage, AssistantMessageEventStream, Context, EventStreamSender, MinimaxCompletions,
+    Model,
 };
 use crate::utils::{ThinkFragment, ThinkTagParser};
 
-const STREAM_INCLUDE_USAGE_FIELD: &str = "include_usage";
-const MAX_TOKENS_FIELD: &str = "max_tokens";
-const REASONING_SPLIT_FIELD: &str = "reasoning_split";
 const REASONING_DETAILS_SIGNATURE: &str = "reasoning_details";
-const REASONING_CONTENT_SIGNATURE: &str = "reasoning_content";
-const REASONING_SIGNATURE: &str = "reasoning";
-const REASONING_TEXT_SIGNATURE: &str = "reasoning_text";
 const THINK_TAG_SIGNATURE: &str = "think_tag";
 const MINIMAX_MIN_TEMPERATURE: f64 = f64::MIN_POSITIVE;
 const MINIMAX_MAX_TEMPERATURE: f64 = 1.0;
@@ -34,37 +27,17 @@ pub fn stream_minimax_completions(
     context: &Context,
     options: OpenAICompletionsOptions,
 ) -> AssistantMessageEventStream {
-    let (stream, sender) = AssistantMessageEventStream::new();
-
-    let model = model.clone();
-    let context = context.clone();
-
-    tokio::spawn(async move {
-        run_stream(model, context, options, sender).await;
-    });
-
-    stream
+    spawn_openai_like_stream(
+        model,
+        context,
+        options,
+        |model, context, options, output, sender| {
+            Box::pin(run_stream(model, context, options, output, sender))
+        },
+    )
 }
 
 async fn run_stream(
-    model: Model<MinimaxCompletions>,
-    context: Context,
-    options: OpenAICompletionsOptions,
-    mut sender: EventStreamSender,
-) {
-    let mut output = initialize_output(
-        Api::MinimaxCompletions,
-        model.provider.clone(),
-        model.id.clone(),
-    );
-
-    if let Err(error) = run_stream_inner(&model, &context, &options, &mut output, &mut sender).await
-    {
-        push_stream_error(&mut output, &mut sender, error);
-    }
-}
-
-async fn run_stream_inner(
     model: &Model<MinimaxCompletions>,
     context: &Context,
     options: &OpenAICompletionsOptions,
@@ -72,27 +45,19 @@ async fn run_stream_inner(
     sender: &mut EventStreamSender,
 ) -> Result<(), crate::Error> {
     let params = build_params(model, context, options);
-    let request = OpenAiLikeRequest {
-        provider: &model.provider,
-        base_url: &model.base_url,
-        api_key: &options.api_key,
-        model_headers: model.headers.as_ref(),
-        request_headers: options.headers.as_ref(),
-        params: &params,
-    };
-
     let mut think_tag_parser = ThinkTagParser::new();
 
-    run_openai_like_stream::<StreamChunk, _, _, _>(
-        request,
+    run_openai_like_stream(
+        OpenAiLikeRequest::new(model, options, &params),
         output,
         sender,
-        &mut think_tag_parser,
-        |chunk, parser, output, sender, current_block| {
-            process_chunk(&chunk, output, sender, current_block, parser);
-        },
-        |parser, output, sender, current_block| {
-            flush_think_tag_parser(parser, output, sender, current_block);
+        |chunk, output, sender, current_block| match chunk {
+            Some(chunk) => {
+                process_chunk(&chunk, output, sender, current_block, &mut think_tag_parser);
+            }
+            None => {
+                emit_think_fragments(think_tag_parser.flush(), output, sender, current_block);
+            }
         },
     )
     .await
@@ -112,23 +77,21 @@ fn build_params(
     let mut params = json!({
         "model": model.id,
         "stream": true,
+        "stream_options": { "include_usage": true },
         "messages": convert_messages(model, context, &message_options),
     });
 
-    let mut stream_options = serde_json::Map::new();
-    stream_options.insert(STREAM_INCLUDE_USAGE_FIELD.to_string(), json!(true));
-    params["stream_options"] = serde_json::Value::Object(stream_options);
-
     if model.reasoning {
-        params[REASONING_SPLIT_FIELD] = json!(true);
+        params["reasoning_split"] = json!(true);
     }
 
     if let Some(max_tokens) = options.max_tokens {
-        params[MAX_TOKENS_FIELD] = json!(max_tokens);
+        params["max_tokens"] = json!(max_tokens);
     }
 
     if let Some(temperature) = options.temperature {
-        params["temperature"] = json!(clamp_temperature(temperature));
+        params["temperature"] =
+            json!(temperature.clamp(MINIMAX_MIN_TEMPERATURE, MINIMAX_MAX_TEMPERATURE));
     }
 
     if let Some(tools) = &context.tools {
@@ -136,31 +99,22 @@ fn build_params(
     }
 
     if let Some(tool_choice) = &options.tool_choice {
-        params["tool_choice"] = serde_json::to_value(tool_choice).unwrap_or(json!("auto"));
+        params["tool_choice"] = json!(tool_choice);
     }
 
     params
 }
 
-fn clamp_temperature(temperature: f64) -> f64 {
-    temperature.clamp(MINIMAX_MIN_TEMPERATURE, MINIMAX_MAX_TEMPERATURE)
-}
-
 fn process_chunk(
-    chunk: &StreamChunk,
+    chunk: &OpenAiLikeStreamChunk,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
     current_block: &mut Option<CurrentBlock>,
     think_tag_parser: &mut ThinkTagParser,
 ) {
-    let Some(prelude) = prepare_openai_like_chunk(
-        chunk,
-        output,
-        sender,
-        current_block,
-        map_stop_reason,
-        delta_tool_calls,
-    ) else {
+    let Some(prelude) =
+        prepare_openai_like_chunk(chunk, output, sender, current_block, map_stop_reason)
+    else {
         return;
     };
 
@@ -171,43 +125,44 @@ fn process_chunk(
         if explicit_reasoning {
             handle_text_delta(content, output, sender, current_block);
         } else {
-            process_content_with_fallback(content, think_tag_parser, output, sender, current_block);
+            // No explicit reasoning fields: reasoning may arrive inline as
+            // <think> tags in the content stream.
+            emit_think_fragments(
+                think_tag_parser.feed(content),
+                output,
+                sender,
+                current_block,
+            );
         }
     }
 
     apply_deferred_tool_calls(prelude, output, sender, current_block);
 }
 
-fn delta_tool_calls(delta: &StreamDelta) -> Option<&[OpenAiLikeToolCallDelta]> {
-    delta.tool_calls.as_deref()
-}
-
 fn emit_explicit_reasoning(
-    delta: &StreamDelta,
+    delta: &OpenAiLikeStreamDelta,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
     current_block: &mut Option<CurrentBlock>,
 ) -> bool {
     let mut emitted_reasoning = false;
 
-    if let Some(details) = &delta.reasoning_details {
-        for detail in details {
-            if let Some(text) = detail.text.as_deref() {
-                if text.is_empty() {
-                    continue;
-                }
-
-                emitted_reasoning = true;
-                handle_reasoning_delta(
-                    ReasoningDelta {
-                        text,
-                        signature: REASONING_DETAILS_SIGNATURE,
-                    },
-                    output,
-                    sender,
-                    current_block,
-                );
+    for detail in delta.reasoning_details.iter().flatten() {
+        if let Some(text) = detail.text.as_deref() {
+            if text.is_empty() {
+                continue;
             }
+
+            emitted_reasoning = true;
+            handle_reasoning_delta(
+                ReasoningDelta {
+                    text,
+                    signature: REASONING_DETAILS_SIGNATURE,
+                },
+                output,
+                sender,
+                current_block,
+            );
         }
     }
 
@@ -215,43 +170,21 @@ fn emit_explicit_reasoning(
         return true;
     }
 
-    for (text, signature) in [
-        (
-            delta.reasoning_content.as_deref(),
-            REASONING_CONTENT_SIGNATURE,
-        ),
-        (delta.reasoning.as_deref(), REASONING_SIGNATURE),
-        (delta.reasoning_text.as_deref(), REASONING_TEXT_SIGNATURE),
-    ] {
-        if let Some(reasoning_text) = text {
-            if reasoning_text.is_empty() {
-                continue;
-            }
-
-            handle_reasoning_delta(
-                ReasoningDelta {
-                    text: reasoning_text,
-                    signature,
-                },
-                output,
-                sender,
-                current_block,
-            );
-            return true;
-        }
+    if let Some(reasoning) = extract_reasoning(delta) {
+        handle_reasoning_delta(reasoning, output, sender, current_block);
+        return true;
     }
 
     false
 }
 
-fn process_content_with_fallback(
-    content: &str,
-    think_tag_parser: &mut ThinkTagParser,
+fn emit_think_fragments(
+    fragments: Vec<ThinkFragment>,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
     current_block: &mut Option<CurrentBlock>,
 ) {
-    for fragment in think_tag_parser.feed(content) {
+    for fragment in fragments {
         match fragment {
             ThinkFragment::Text(text) => {
                 handle_text_delta(&text, output, sender, current_block);
@@ -269,65 +202,18 @@ fn process_content_with_fallback(
             }
         }
     }
-}
-
-fn flush_think_tag_parser(
-    think_tag_parser: &mut ThinkTagParser,
-    output: &mut AssistantMessage,
-    sender: &mut EventStreamSender,
-    current_block: &mut Option<CurrentBlock>,
-) {
-    for fragment in think_tag_parser.flush() {
-        match fragment {
-            ThinkFragment::Text(text) => {
-                handle_text_delta(&text, output, sender, current_block);
-            }
-            ThinkFragment::Thinking(thinking) => {
-                handle_reasoning_delta(
-                    ReasoningDelta {
-                        text: &thinking,
-                        signature: THINK_TAG_SIGNATURE,
-                    },
-                    output,
-                    sender,
-                    current_block,
-                );
-            }
-        }
-    }
-}
-
-type StreamChunk = OpenAiLikeStreamChunk<StreamDelta>;
-
-#[derive(Debug, Deserialize)]
-struct StreamDelta {
-    content: Option<String>,
-    reasoning_details: Option<Vec<ReasoningDetail>>,
-    reasoning_content: Option<String>,
-    reasoning: Option<String>,
-    reasoning_text: Option<String>,
-    tool_calls: Option<Vec<OpenAiLikeToolCallDelta>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ReasoningDetail {
-    #[serde(rename = "type")]
-    _detail_type: Option<String>,
-    _id: Option<String>,
-    _format: Option<String>,
-    _index: Option<u32>,
-    text: Option<String>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_helpers::{
-        assert_final_message_shape, build_final_message_shape_chunks, ExpectedFinalMessageShape,
+        assert_final_message_shape, assert_multiply_tool_call, build_final_message_shape_chunks,
+        concise_context, make_test_model, tool_call_continuation_chunk, tool_call_start_chunk,
+        ExpectedFinalMessageShape,
     };
     use crate::types::{
-        AssistantMessageEvent, Content, InputType, KnownProvider, Message, ModelCost, Provider,
-        StopReason, Usage, UserContent, UserMessage,
+        Api, AssistantMessageEvent, Content, KnownProvider, Message, Provider, StopReason, Usage,
     };
     use futures::executor::block_on;
     use futures::StreamExt;
@@ -335,56 +221,24 @@ mod tests {
     const TEST_BASE_URL: &str = "https://api.minimax.io/v1/chat/completions";
 
     fn make_model(reasoning: bool) -> Model<MinimaxCompletions> {
-        Model {
-            id: "MiniMax-M2.5".to_string(),
-            name: "MiniMax M2.5".to_string(),
-            api: MinimaxCompletions,
-            provider: Provider::Known(KnownProvider::Minimax),
-            base_url: TEST_BASE_URL.to_string(),
+        make_test_model(
+            MinimaxCompletions,
+            KnownProvider::Minimax,
+            "MiniMax-M2.5",
+            TEST_BASE_URL,
             reasoning,
-            input: vec![InputType::Text],
-            cost: ModelCost {
-                input: 0.0,
-                output: 0.0,
-                cache_read: 0.0,
-                cache_write: 0.0,
-            },
-            context_window: 204_800,
-            max_tokens: 16_384,
-            headers: None,
-            compat: None,
-        }
-    }
-
-    fn make_context() -> Context {
-        Context {
-            system_prompt: Some("You are concise".to_string()),
-            messages: vec![crate::types::Message::User(UserMessage {
-                content: UserContent::Text("Hello".to_string()),
-                timestamp: 0,
-            })],
-            tools: None,
-        }
-    }
-
-    fn make_output_message() -> AssistantMessage {
-        AssistantMessage {
-            content: vec![],
-            api: Api::MinimaxCompletions,
-            provider: Provider::Known(KnownProvider::Minimax),
-            model: "MiniMax-M2.5".to_string(),
-            usage: Usage::default(),
-            stop_reason: StopReason::Stop,
-            error_message: None,
-            timestamp: 0,
-        }
+        )
     }
 
     fn process_chunks_for_test(
-        chunks: Vec<StreamChunk>,
+        chunks: Vec<OpenAiLikeStreamChunk>,
     ) -> (Vec<AssistantMessageEvent>, AssistantMessage) {
         let (mut stream, mut sender) = AssistantMessageEventStream::new();
-        let mut output = make_output_message();
+        let mut output = initialize_output(
+            Api::MinimaxCompletions,
+            Provider::Known(KnownProvider::Minimax),
+            "MiniMax-M2.5".to_string(),
+        );
         let mut current_block = None;
         let mut parser = ThinkTagParser::new();
 
@@ -398,7 +252,7 @@ mod tests {
             );
         }
 
-        flush_think_tag_parser(&mut parser, &mut output, &mut sender, &mut current_block);
+        emit_think_fragments(parser.flush(), &mut output, &mut sender, &mut current_block);
         finish_current_block(&mut current_block, &mut output, &mut sender);
 
         drop(sender);
@@ -407,82 +261,8 @@ mod tests {
         (events, output)
     }
 
-    fn tool_call_start_chunk(call_id: &str) -> StreamChunk {
-        serde_json::from_value(serde_json::json!({
-            "choices": [{
-                "delta": {
-                    "tool_calls": [{
-                        "id": call_id,
-                        "type": "function",
-                        "function": {
-                            "name": "multiply",
-                            "arguments": "{\"a\": 15, \"b\": "
-                        },
-                        "index": 0
-                    }]
-                }
-            }]
-        }))
-        .expect("valid first tool-call chunk")
-    }
-
-    fn tool_call_continuation_with_content_chunk(content: &str) -> StreamChunk {
-        serde_json::from_value(serde_json::json!({
-            "choices": [{
-                "finish_reason": "tool_calls",
-                "delta": {
-                    "content": content,
-                    "tool_calls": [{
-                        "type": "function",
-                        "function": {
-                            "arguments": "3}"
-                        },
-                        "index": 0
-                    }]
-                }
-            }]
-        }))
-        .expect("valid interleaved continuation chunk")
-    }
-
-    fn tool_call_continuation_with_reasoning_chunk(reasoning_text: &str) -> StreamChunk {
-        serde_json::from_value(serde_json::json!({
-            "choices": [{
-                "finish_reason": "tool_calls",
-                "delta": {
-                    "reasoning_details": [{
-                        "type": "reasoning",
-                        "id": "r-1",
-                        "format": "text",
-                        "index": 0,
-                        "text": reasoning_text
-                    }],
-                    "tool_calls": [{
-                        "type": "function",
-                        "function": {
-                            "arguments": "3}"
-                        },
-                        "index": 0
-                    }]
-                }
-            }]
-        }))
-        .expect("valid interleaved reasoning continuation chunk")
-    }
-
-    fn assert_multiply_tool_call(content: &Content, expected_call_id: &str) {
-        match content {
-            Content::ToolCall { inner } => {
-                assert_eq!(inner.id.as_str(), expected_call_id);
-                assert_eq!(inner.name, "multiply");
-                assert_eq!(inner.arguments, serde_json::json!({"a": 15, "b": 3}));
-            }
-            _ => panic!("expected tool call content"),
-        }
-    }
-
     fn run_interleaved_tool_call_case(
-        chunks: Vec<StreamChunk>,
+        chunks: Vec<OpenAiLikeStreamChunk>,
         expected_call_id: &str,
     ) -> AssistantMessage {
         let (_events, output) = process_chunks_for_test(chunks);
@@ -549,7 +329,7 @@ mod tests {
     #[test]
     fn build_params_for_reasoning_model_uses_minimax_semantics() {
         let model = make_model(true);
-        let context = make_context();
+        let context = concise_context();
         let options = OpenAICompletionsOptions {
             temperature: Some(1.2),
             max_tokens: Some(512),
@@ -559,9 +339,9 @@ mod tests {
         let params = build_params(&model, &context, &options);
 
         assert_eq!(params["stream"], true);
-        assert_eq!(params["stream_options"][STREAM_INCLUDE_USAGE_FIELD], true);
-        assert_eq!(params[REASONING_SPLIT_FIELD], true);
-        assert_eq!(params[MAX_TOKENS_FIELD], 512);
+        assert_eq!(params["stream_options"]["include_usage"], true);
+        assert_eq!(params["reasoning_split"], true);
+        assert_eq!(params["max_tokens"], 512);
         assert_eq!(params["temperature"], MINIMAX_MAX_TEMPERATURE);
         assert_eq!(params["messages"][0]["role"], "system");
         assert_eq!(params["messages"][0]["content"], "You are concise");
@@ -572,18 +352,18 @@ mod tests {
     #[test]
     fn build_params_for_non_reasoning_model_omits_reasoning_split() {
         let model = make_model(false);
-        let context = make_context();
+        let context = concise_context();
         let options = OpenAICompletionsOptions::default();
 
         let params = build_params(&model, &context, &options);
 
-        assert!(params.get(REASONING_SPLIT_FIELD).is_none());
+        assert!(params.get("reasoning_split").is_none());
     }
 
     #[test]
     fn build_params_clamps_temperature_to_positive_lower_bound() {
         let model = make_model(true);
-        let context = make_context();
+        let context = concise_context();
         let options = OpenAICompletionsOptions {
             temperature: Some(0.0),
             ..OpenAICompletionsOptions::default()
@@ -625,7 +405,7 @@ mod tests {
 
     #[test]
     fn process_chunk_maps_reasoning_details_to_thinking_events() {
-        let chunk: StreamChunk = serde_json::from_value(serde_json::json!({
+        let chunk: OpenAiLikeStreamChunk = serde_json::from_value(serde_json::json!({
             "choices": [{
                 "delta": {
                     "reasoning_details": [
@@ -643,8 +423,28 @@ mod tests {
     }
 
     #[test]
+    fn process_chunk_skips_empty_reasoning_fields_before_think_tag_fallback() {
+        let chunk: OpenAiLikeStreamChunk = serde_json::from_value(serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "reasoning_content": "",
+                    "reasoning": "step one",
+                    "content": "answer"
+                }
+            }]
+        }))
+        .expect("valid mixed reasoning payload");
+
+        let (_events, output) = process_chunks_for_test(vec![chunk]);
+
+        assert_eq!(output.content.len(), 2);
+        assert_thinking_content(&output.content[0], "step one", "reasoning");
+        assert_text_content(&output.content[1], "answer");
+    }
+
+    #[test]
     fn process_chunk_with_inline_think_tags_emits_expected_event_order() {
-        let chunk: StreamChunk = serde_json::from_value(serde_json::json!({
+        let chunk: OpenAiLikeStreamChunk = serde_json::from_value(serde_json::json!({
             "choices": [{
                 "delta": {
                     "content": "<think>reason</think>answer"
@@ -668,17 +468,12 @@ mod tests {
         let output = run_interleaved_tool_call_case(
             vec![
                 tool_call_start_chunk("call_function_1"),
-                tool_call_continuation_with_content_chunk("tail"),
+                tool_call_continuation_chunk(serde_json::json!({ "content": "tail" })),
             ],
             "call_function_1",
         );
 
-        match &output.content[1] {
-            Content::Text { inner } => {
-                assert_eq!(inner.text, "tail");
-            }
-            _ => panic!("expected text content"),
-        }
+        assert_text_content(&output.content[1], "tail");
     }
 
     #[test]
@@ -686,26 +481,25 @@ mod tests {
         let output = run_interleaved_tool_call_case(
             vec![
                 tool_call_start_chunk("call_function_2"),
-                tool_call_continuation_with_reasoning_chunk("next step"),
+                tool_call_continuation_chunk(serde_json::json!({
+                    "reasoning_details": [{
+                        "type": "reasoning",
+                        "id": "r-1",
+                        "format": "text",
+                        "index": 0,
+                        "text": "next step"
+                    }]
+                })),
             ],
             "call_function_2",
         );
 
-        match &output.content[1] {
-            Content::Thinking { inner } => {
-                assert_eq!(inner.thinking, "next step");
-                assert_eq!(
-                    inner.thinking_signature.as_deref(),
-                    Some(REASONING_DETAILS_SIGNATURE)
-                );
-            }
-            _ => panic!("expected thinking content"),
-        }
+        assert_thinking_content(&output.content[1], "next step", REASONING_DETAILS_SIGNATURE);
     }
 
     #[test]
     fn usage_only_chunk_updates_output_usage() {
-        let chunk: StreamChunk = serde_json::from_value(serde_json::json!({
+        let chunk: OpenAiLikeStreamChunk = serde_json::from_value(serde_json::json!({
             "choices": [],
             "usage": {
                 "prompt_tokens": 12,
@@ -724,7 +518,7 @@ mod tests {
 
     #[test]
     fn stream_minimax_completions_final_message_shape() {
-        let chunks = build_final_message_shape_chunks::<StreamChunk>(serde_json::json!({
+        let chunks = build_final_message_shape_chunks(serde_json::json!({
             "reasoning_details": [{"text": "reason"}]
         }));
         let (_events, output) = process_chunks_for_test(chunks);

--- a/src/providers/openai_completions.rs
+++ b/src/providers/openai_completions.rs
@@ -3,17 +3,16 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-#[cfg(test)]
-use super::shared::finish_current_block;
 use super::shared::{
-    convert_messages, convert_tools, handle_reasoning_delta, handle_text_delta, handle_tool_calls,
-    initialize_output, map_stop_reason, push_stream_error, run_openai_like_stream_without_state,
-    update_usage_from_chunk, AssistantThinkingMode, CurrentBlock, OpenAiLikeMessageOptions,
-    OpenAiLikeRequest, OpenAiLikeStreamChunk, OpenAiLikeToolCallDelta, ReasoningDelta,
-    SystemPromptRole,
+    apply_deferred_tool_calls, convert_messages, convert_tools, extract_reasoning,
+    handle_reasoning_delta, handle_text_delta, map_stop_reason, prepare_openai_like_chunk,
+    run_openai_like_stream, spawn_openai_like_stream, AssistantThinkingMode, CurrentBlock,
+    OpenAiLikeMessageOptions, OpenAiLikeRequest, OpenAiLikeStreamChunk, SystemPromptRole,
 };
+#[cfg(test)]
+use super::shared::{finish_current_block, initialize_output};
 use crate::types::{
-    Api, AssistantMessage, AssistantMessageEventStream, Context, EventStreamSender, KnownProvider,
+    AssistantMessage, AssistantMessageEventStream, Context, EventStreamSender, KnownProvider,
     MaxTokensField, Model, OpenAICompletions, OpenAICompletionsCompat, Provider,
 };
 
@@ -65,8 +64,9 @@ struct ResolvedCompat {
     requires_mistral_tool_ids: bool,
 }
 
-impl From<(ResolvedCompat, &OpenAICompletionsCompat)> for ResolvedCompat {
-    fn from((detected, explicit): (ResolvedCompat, &OpenAICompletionsCompat)) -> Self {
+impl ResolvedCompat {
+    /// Apply explicit model-specified overrides on top of detected defaults.
+    fn with_overrides(detected: Self, explicit: &OpenAICompletionsCompat) -> Self {
         Self {
             supports_store: explicit.supports_store.unwrap_or(detected.supports_store),
             supports_developer_role: explicit
@@ -103,37 +103,17 @@ pub fn stream_openai_completions(
     context: &Context,
     options: OpenAICompletionsOptions,
 ) -> AssistantMessageEventStream {
-    let (stream, sender) = AssistantMessageEventStream::new();
-
-    let model = model.clone();
-    let context = context.clone();
-
-    tokio::spawn(async move {
-        run_stream(model, context, options, sender).await;
-    });
-
-    stream
+    spawn_openai_like_stream(
+        model,
+        context,
+        options,
+        |model, context, options, output, sender| {
+            Box::pin(run_stream(model, context, options, output, sender))
+        },
+    )
 }
 
 async fn run_stream(
-    model: Model<OpenAICompletions>,
-    context: Context,
-    options: OpenAICompletionsOptions,
-    mut sender: EventStreamSender,
-) {
-    let mut output = initialize_output(
-        Api::OpenAICompletions,
-        model.provider.clone(),
-        model.id.clone(),
-    );
-
-    if let Err(error) = run_stream_inner(&model, &context, &options, &mut output, &mut sender).await
-    {
-        push_stream_error(&mut output, &mut sender, error);
-    }
-}
-
-async fn run_stream_inner(
     model: &Model<OpenAICompletions>,
     context: &Context,
     options: &OpenAICompletionsOptions,
@@ -142,84 +122,41 @@ async fn run_stream_inner(
 ) -> Result<(), crate::Error> {
     let compat = resolve_compat(model);
     let params = build_params(model, context, options, &compat);
-    let request = OpenAiLikeRequest::new(
-        &model.provider,
-        &model.base_url,
-        &options.api_key,
-        model.headers.as_ref(),
-        options.headers.as_ref(),
-        &params,
-    );
 
-    run_openai_like_stream_without_state::<StreamChunk, _>(
-        request,
+    run_openai_like_stream(
+        OpenAiLikeRequest::new(model, options, &params),
         output,
         sender,
         |chunk, output, sender, current_block| {
-            process_chunk(&chunk, output, sender, current_block);
+            if let Some(chunk) = chunk {
+                process_chunk(&chunk, output, sender, current_block);
+            }
         },
     )
     .await
 }
 
-const REASONING_CONTENT_FIELD: &str = "reasoning_content";
-const REASONING_FIELD: &str = "reasoning";
-const REASONING_TEXT_FIELD: &str = "reasoning_text";
-
 fn process_chunk(
-    chunk: &StreamChunk,
+    chunk: &OpenAiLikeStreamChunk,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
     current_block: &mut Option<CurrentBlock>,
 ) {
-    if let Some(usage) = &chunk.usage {
-        update_usage_from_chunk(usage, output);
-    }
-
-    let Some(choice) = chunk.choices.first() else {
+    let Some(prelude) =
+        prepare_openai_like_chunk(chunk, output, sender, current_block, map_stop_reason)
+    else {
         return;
     };
 
-    if let Some(reason) = &choice.finish_reason {
-        output.stop_reason = map_stop_reason(reason);
-    }
-
-    let Some(delta) = &choice.delta else {
-        return;
-    };
-
-    if let Some(content) = delta.content.as_deref() {
+    if let Some(content) = prelude.delta.content.as_deref() {
         handle_text_delta(content, output, sender, current_block);
     }
 
-    if let Some(reasoning) = extract_reasoning(delta) {
+    if let Some(reasoning) = extract_reasoning(prelude.delta) {
         handle_reasoning_delta(reasoning, output, sender, current_block);
     }
 
-    if let Some(tool_calls) = &delta.tool_calls {
-        handle_tool_calls(tool_calls, output, sender, current_block);
-    }
-}
-
-fn extract_reasoning(delta: &StreamDelta) -> Option<ReasoningDelta<'_>> {
-    if let Some(text) = delta.reasoning_content.as_deref() {
-        return Some(ReasoningDelta {
-            text,
-            signature: REASONING_CONTENT_FIELD,
-        });
-    }
-
-    if let Some(text) = delta.reasoning.as_deref() {
-        return Some(ReasoningDelta {
-            text,
-            signature: REASONING_FIELD,
-        });
-    }
-
-    delta.reasoning_text.as_deref().map(|text| ReasoningDelta {
-        text,
-        signature: REASONING_TEXT_FIELD,
-    })
+    apply_deferred_tool_calls(prelude, output, sender, current_block);
 }
 
 fn build_params(
@@ -345,66 +282,32 @@ fn resolve_compat(model: &Model<OpenAICompletions>) -> ResolvedCompat {
     let detected = detect_compat(model);
 
     match model.compat.as_ref() {
-        Some(explicit) => ResolvedCompat::from((detected, explicit)),
+        Some(explicit) => ResolvedCompat::with_overrides(detected, explicit),
         None => detected,
     }
-}
-
-type StreamChunk = OpenAiLikeStreamChunk<StreamDelta>;
-
-#[derive(Debug, Deserialize)]
-struct StreamDelta {
-    content: Option<String>,
-    reasoning_content: Option<String>,
-    reasoning: Option<String>,
-    reasoning_text: Option<String>,
-    tool_calls: Option<Vec<OpenAiLikeToolCallDelta>>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_helpers::{
-        assert_final_message_shape, build_final_message_shape_chunks, ExpectedFinalMessageShape,
+        assert_final_message_shape, build_final_message_shape_chunks, make_test_model,
+        ExpectedFinalMessageShape,
     };
     use crate::types::{
-        Context, InputType, MaxTokensField, Message, ModelCost, StopReason, UserContent,
-        UserMessage,
+        Api, Context, MaxTokensField, Message, StopReason, UserContent, UserMessage,
     };
     use futures::executor::block_on;
     use futures::StreamExt;
     use serde_json::json;
 
-    fn make_test_model(
-        id: &str,
-        name: &str,
-        provider: KnownProvider,
-        base_url: &str,
-    ) -> Model<OpenAICompletions> {
-        Model {
-            id: id.to_string(),
-            name: name.to_string(),
-            api: OpenAICompletions,
-            provider: Provider::Known(provider),
-            base_url: base_url.to_string(),
-            reasoning: false,
-            input: vec![InputType::Text],
-            cost: ModelCost {
-                input: 0.0,
-                output: 0.0,
-                cache_read: 0.0,
-                cache_write: 0.0,
-            },
-            context_window: 128_000,
-            max_tokens: 4_096,
-            headers: None,
-            compat: None,
-        }
+    fn make_model(provider: KnownProvider, id: &str, base_url: &str) -> Model<OpenAICompletions> {
+        make_test_model(OpenAICompletions, provider, id, base_url, false)
     }
 
     fn process_chunks_for_test(
         model: &Model<OpenAICompletions>,
-        chunks: Vec<StreamChunk>,
+        chunks: Vec<OpenAiLikeStreamChunk>,
     ) -> AssistantMessage {
         let (mut stream, mut sender) = AssistantMessageEventStream::new();
         let mut output = initialize_output(
@@ -427,10 +330,9 @@ mod tests {
 
     #[test]
     fn detect_compat_for_openai_defaults() {
-        let model = make_test_model(
-            "gpt-4",
-            "GPT-4",
+        let model = make_model(
             KnownProvider::OpenAI,
+            "gpt-4",
             "https://api.openai.com/v1/chat/completions",
         );
 
@@ -444,10 +346,9 @@ mod tests {
 
     #[test]
     fn detect_compat_for_mistral_defaults() {
-        let model = make_test_model(
-            "mistral-large",
-            "Mistral Large",
+        let model = make_model(
             KnownProvider::Mistral,
+            "mistral-large",
             "https://api.mistral.ai/v1/chat/completions",
         );
 
@@ -461,10 +362,9 @@ mod tests {
 
     #[test]
     fn detect_compat_for_featherless_defaults() {
-        let model = make_test_model(
-            "moonshotai/Kimi-K2.5",
-            "Kimi K2.5",
+        let model = make_model(
             KnownProvider::Featherless,
+            "moonshotai/Kimi-K2.5",
             "https://api.featherless.ai/v1/chat/completions",
         );
 
@@ -479,10 +379,9 @@ mod tests {
 
     #[test]
     fn build_params_uses_max_tokens_for_featherless() {
-        let model = make_test_model(
-            "moonshotai/Kimi-K2.5",
-            "Kimi K2.5",
+        let model = make_model(
             KnownProvider::Featherless,
+            "moonshotai/Kimi-K2.5",
             "https://api.featherless.ai/v1/chat/completions",
         );
         let context = Context {
@@ -510,13 +409,12 @@ mod tests {
 
     #[test]
     fn stream_featherless_openai_compatible_runtime_returns_expected_message_shape() {
-        let model = make_test_model(
-            "moonshotai/Kimi-K2.5",
-            "Kimi K2.5",
+        let model = make_model(
             KnownProvider::Featherless,
+            "moonshotai/Kimi-K2.5",
             "https://api.featherless.ai/v1/chat/completions",
         );
-        let chunks = build_final_message_shape_chunks::<StreamChunk>(json!({
+        let chunks = build_final_message_shape_chunks(json!({
             "reasoning": "thinking"
         }));
         let result = process_chunks_for_test(&model, chunks);

--- a/src/providers/shared/mod.rs
+++ b/src/providers/shared/mod.rs
@@ -17,11 +17,13 @@ pub(crate) use openai_like_messages::{
 };
 pub(crate) use openai_like_runtime::{
     initialize_output, process_sse_stream_with_event, push_stream_done, push_stream_error,
-    run_openai_like_stream, run_openai_like_stream_without_state, OpenAiLikeRequest,
+    run_openai_like_stream, spawn_openai_like_stream, OpenAiLikeRequest,
 };
 pub(crate) use stream_blocks::finish_current_block;
+#[cfg(test)]
+pub(crate) use stream_blocks::REASONING_CONTENT_SIGNATURE;
 pub(crate) use stream_blocks::{
-    apply_deferred_tool_calls, handle_reasoning_delta, handle_text_delta, handle_tool_calls,
-    map_stop_reason, prepare_openai_like_chunk, update_usage_from_chunk, CurrentBlock,
-    OpenAiLikeStreamChunk, OpenAiLikeToolCallDelta, ReasoningDelta,
+    apply_deferred_tool_calls, extract_reasoning, handle_reasoning_delta, handle_text_delta,
+    map_stop_reason, prepare_openai_like_chunk, CurrentBlock, OpenAiLikeStreamChunk,
+    OpenAiLikeStreamDelta, ReasoningDelta,
 };

--- a/src/providers/shared/openai_like_runtime.rs
+++ b/src/providers/shared/openai_like_runtime.rs
@@ -1,15 +1,17 @@
 use std::collections::HashMap;
 
+use futures::future::BoxFuture;
 use futures::StreamExt;
 use serde::de::DeserializeOwned;
 
+use crate::providers::OpenAICompletionsOptions;
 use crate::types::{
-    Api, AssistantMessage, AssistantMessageEvent, EventStreamSender, Provider, StopReason,
-    StopReasonError, StopReasonSuccess, Usage,
+    Api, ApiType, AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream, Context,
+    EventStreamSender, Model, Provider, StopReason, StopReasonError, StopReasonSuccess, Usage,
 };
 
 use super::http::build_http_client;
-use super::stream_blocks::{finish_current_block, CurrentBlock};
+use super::stream_blocks::{finish_current_block, CurrentBlock, OpenAiLikeStreamChunk};
 use super::timestamp::unix_timestamp_millis;
 
 pub(crate) struct OpenAiLikeRequest<'a> {
@@ -22,20 +24,17 @@ pub(crate) struct OpenAiLikeRequest<'a> {
 }
 
 impl<'a> OpenAiLikeRequest<'a> {
-    pub(crate) fn new(
-        provider: &'a Provider,
-        base_url: &'a str,
-        api_key: &'a Option<String>,
-        model_headers: Option<&'a HashMap<String, String>>,
-        request_headers: Option<&'a HashMap<String, String>>,
+    pub(crate) fn new<TApi: ApiType>(
+        model: &'a Model<TApi>,
+        options: &'a OpenAICompletionsOptions,
         params: &'a serde_json::Value,
     ) -> Self {
         Self {
-            provider,
-            base_url,
-            api_key,
-            model_headers,
-            request_headers,
+            provider: &model.provider,
+            base_url: &model.base_url,
+            api_key: &options.api_key,
+            model_headers: model.headers.as_ref(),
+            request_headers: options.headers.as_ref(),
             params,
         }
     }
@@ -84,25 +83,61 @@ pub(crate) fn push_stream_done(output: &AssistantMessage, sender: &mut EventStre
     });
 }
 
-pub(crate) async fn run_openai_like_stream<TChunk, TState, FChunk, FBeforeFinish>(
+/// The per-provider streaming body driven by [`spawn_openai_like_stream`].
+///
+/// Plain `fn` (not a closure trait) so the returned future can borrow its
+/// arguments; non-capturing closures at call sites coerce to it.
+pub(crate) type RunStreamFn<TApi> = for<'a> fn(
+    &'a Model<TApi>,
+    &'a Context,
+    &'a OpenAICompletionsOptions,
+    &'a mut AssistantMessage,
+    &'a mut EventStreamSender,
+) -> BoxFuture<'a, Result<(), crate::Error>>;
+
+/// Spawn the streaming task shared by every OpenAI-like provider: create the
+/// event stream, initialize the output message, run the provider body, and
+/// convert any error into a stream error event.
+pub(crate) fn spawn_openai_like_stream<TApi>(
+    model: &Model<TApi>,
+    context: &Context,
+    options: OpenAICompletionsOptions,
+    run_stream: RunStreamFn<TApi>,
+) -> AssistantMessageEventStream
+where
+    TApi: ApiType,
+    Model<TApi>: Clone + Send + 'static,
+{
+    let (stream, mut sender) = AssistantMessageEventStream::new();
+    let api = model.api.api();
+    let model = model.clone();
+    let context = context.clone();
+
+    tokio::spawn(async move {
+        let mut output = initialize_output(api, model.provider.clone(), model.id.clone());
+
+        if let Err(error) = run_stream(&model, &context, &options, &mut output, &mut sender).await {
+            push_stream_error(&mut output, &mut sender, error);
+        }
+    });
+
+    stream
+}
+
+/// Send the request and drive the SSE stream through `on_event`.
+///
+/// `on_event` receives `Some(chunk)` for each parsed chunk and a final `None`
+/// once the stream ends, so handlers can flush any buffered state before the
+/// current block is finished.
+pub(crate) async fn run_openai_like_stream<F>(
     request: OpenAiLikeRequest<'_>,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
-    state: &mut TState,
-    mut process_chunk: FChunk,
-    mut before_finish: FBeforeFinish,
+    mut on_event: F,
 ) -> Result<(), crate::Error>
 where
-    TChunk: DeserializeOwned,
-    FChunk: FnMut(
-        TChunk,
-        &mut TState,
-        &mut AssistantMessage,
-        &mut EventStreamSender,
-        &mut Option<CurrentBlock>,
-    ),
-    FBeforeFinish: FnMut(
-        &mut TState,
+    F: FnMut(
+        Option<OpenAiLikeStreamChunk>,
         &mut AssistantMessage,
         &mut EventStreamSender,
         &mut Option<CurrentBlock>,
@@ -118,41 +153,16 @@ where
 
     let mut current_block: Option<CurrentBlock> = None;
 
-    process_sse_stream::<TChunk, _>(response, |chunk| {
-        process_chunk(chunk, state, output, sender, &mut current_block);
+    process_sse_stream::<OpenAiLikeStreamChunk, _>(response, |chunk| {
+        on_event(Some(chunk), output, sender, &mut current_block);
     })
     .await?;
 
-    before_finish(state, output, sender, &mut current_block);
+    on_event(None, output, sender, &mut current_block);
     finish_current_block(&mut current_block, output, sender);
     push_stream_done(output, sender);
 
     Ok(())
-}
-
-pub(crate) async fn run_openai_like_stream_without_state<TChunk, FChunk>(
-    request: OpenAiLikeRequest<'_>,
-    output: &mut AssistantMessage,
-    sender: &mut EventStreamSender,
-    mut process_chunk: FChunk,
-) -> Result<(), crate::Error>
-where
-    TChunk: DeserializeOwned,
-    FChunk: FnMut(TChunk, &mut AssistantMessage, &mut EventStreamSender, &mut Option<CurrentBlock>),
-{
-    let mut state = ();
-
-    run_openai_like_stream::<TChunk, _, _, _>(
-        request,
-        output,
-        sender,
-        &mut state,
-        |chunk, _state, output, sender, current_block| {
-            process_chunk(chunk, output, sender, current_block);
-        },
-        |_state, _output, _sender, _current_block| {},
-    )
-    .await
 }
 
 fn done_reason_from_stop_reason(stop_reason: StopReason) -> StopReasonSuccess {
@@ -192,40 +202,7 @@ where
     TChunk: DeserializeOwned,
     F: FnMut(TChunk),
 {
-    let mut stream = response.bytes_stream();
-    let mut buffer = String::new();
-    let mut done_received = false;
-
-    while let Some(chunk_result) = stream.next().await {
-        let chunk = chunk_result?;
-        buffer.push_str(&String::from_utf8_lossy(&chunk));
-
-        while let Some(line_end) = buffer.find('\n') {
-            let line = buffer[..line_end].trim().to_string();
-            buffer = buffer[line_end + 1..].to_string();
-
-            if line.is_empty() || line.starts_with(':') {
-                continue;
-            }
-
-            if let Some(data) = sse_field_value(&line, "data") {
-                if data == "[DONE]" {
-                    done_received = true;
-                    break;
-                }
-
-                if let Ok(chunk) = serde_json::from_str::<TChunk>(data) {
-                    on_chunk(chunk);
-                }
-            }
-        }
-
-        if done_received {
-            break;
-        }
-    }
-
-    Ok(())
+    process_sse_stream_with_event(response, |_event_type, chunk| on_chunk(chunk)).await
 }
 
 pub(crate) async fn process_sse_stream_with_event<TChunk, F>(
@@ -239,6 +216,7 @@ where
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
     let mut current_event_type = String::new();
+    let mut done_received = false;
 
     while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result?;
@@ -258,8 +236,8 @@ where
             }
 
             if let Some(data) = sse_field_value(&line, "data") {
-                let data = data.trim();
                 if data == "[DONE]" {
+                    done_received = true;
                     break;
                 }
                 if let Ok(parsed) = serde_json::from_str::<TChunk>(data) {
@@ -267,6 +245,10 @@ where
                 }
                 current_event_type.clear();
             }
+        }
+
+        if done_received {
+            break;
         }
     }
 

--- a/src/providers/shared/stream_blocks.rs
+++ b/src/providers/shared/stream_blocks.rs
@@ -26,6 +26,10 @@ pub(crate) struct ReasoningDelta<'a> {
     pub signature: &'a str,
 }
 
+pub(crate) const REASONING_CONTENT_SIGNATURE: &str = "reasoning_content";
+pub(crate) const REASONING_SIGNATURE: &str = "reasoning";
+pub(crate) const REASONING_TEXT_SIGNATURE: &str = "reasoning_text";
+
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct OpenAiLikeToolCallDelta {
     pub id: Option<String>,
@@ -39,23 +43,53 @@ pub(crate) struct OpenAiLikeFunctionDelta {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(bound(deserialize = "TDelta: Deserialize<'de>"))]
-pub(crate) struct OpenAiLikeStreamChunk<TDelta> {
+pub(crate) struct OpenAiLikeStreamChunk {
     #[serde(default)]
-    pub choices: Vec<OpenAiLikeStreamChoice<TDelta>>,
+    pub choices: Vec<OpenAiLikeStreamChoice>,
     pub usage: Option<OpenAiLikeStreamUsage>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(bound(deserialize = "TDelta: Deserialize<'de>"))]
-pub(crate) struct OpenAiLikeStreamChoice<TDelta> {
-    pub delta: Option<TDelta>,
+pub(crate) struct OpenAiLikeStreamChoice {
+    pub delta: Option<OpenAiLikeStreamDelta>,
     pub finish_reason: Option<String>,
 }
 
-pub(crate) struct OpenAiLikeChunkPrelude<'a, TDelta> {
-    pub delta: &'a TDelta,
-    tool_calls: Option<&'a [OpenAiLikeToolCallDelta]>,
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiLikeStreamDelta {
+    pub content: Option<String>,
+    pub reasoning_details: Option<Vec<ReasoningDetail>>,
+    pub reasoning_content: Option<String>,
+    pub reasoning: Option<String>,
+    pub reasoning_text: Option<String>,
+    pub tool_calls: Option<Vec<OpenAiLikeToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ReasoningDetail {
+    pub text: Option<String>,
+}
+
+/// Extract reasoning from the first non-empty of the field names providers
+/// use for it, tagging the delta with the source field as its signature.
+pub(crate) fn extract_reasoning(delta: &OpenAiLikeStreamDelta) -> Option<ReasoningDelta<'_>> {
+    [
+        (
+            delta.reasoning_content.as_deref(),
+            REASONING_CONTENT_SIGNATURE,
+        ),
+        (delta.reasoning.as_deref(), REASONING_SIGNATURE),
+        (delta.reasoning_text.as_deref(), REASONING_TEXT_SIGNATURE),
+    ]
+    .into_iter()
+    .find_map(|(text, signature)| {
+        text.filter(|text| !text.is_empty())
+            .map(|text| ReasoningDelta { text, signature })
+    })
+}
+
+pub(crate) struct OpenAiLikeChunkPrelude<'a> {
+    pub delta: &'a OpenAiLikeStreamDelta,
     prioritize_tool_calls: bool,
 }
 
@@ -167,18 +201,13 @@ pub(crate) fn update_usage_from_chunk(
     };
 }
 
-pub(crate) fn prepare_openai_like_chunk<'a, TDelta, FStopReason, FToolCalls>(
-    chunk: &'a OpenAiLikeStreamChunk<TDelta>,
+pub(crate) fn prepare_openai_like_chunk<'a>(
+    chunk: &'a OpenAiLikeStreamChunk,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
     current_block: &mut Option<CurrentBlock>,
-    map_stop_reason: FStopReason,
-    delta_tool_calls: FToolCalls,
-) -> Option<OpenAiLikeChunkPrelude<'a, TDelta>>
-where
-    FStopReason: Fn(&str) -> StopReason,
-    FToolCalls: Fn(&'a TDelta) -> Option<&'a [OpenAiLikeToolCallDelta]>,
-{
+    map_stop_reason: impl Fn(&str) -> StopReason,
+) -> Option<OpenAiLikeChunkPrelude<'a>> {
     if let Some(usage) = &chunk.usage {
         update_usage_from_chunk(usage, output);
     }
@@ -190,25 +219,23 @@ where
     }
 
     let delta = choice.delta.as_ref()?;
-    let tool_calls = delta_tool_calls(delta);
     let prioritize_tool_calls =
-        matches!(current_block, Some(CurrentBlock::ToolCall { .. })) && tool_calls.is_some();
+        matches!(current_block, Some(CurrentBlock::ToolCall { .. })) && delta.tool_calls.is_some();
 
     if prioritize_tool_calls {
-        if let Some(tool_call_deltas) = tool_calls {
+        if let Some(tool_call_deltas) = &delta.tool_calls {
             handle_tool_calls(tool_call_deltas, output, sender, current_block);
         }
     }
 
     Some(OpenAiLikeChunkPrelude {
         delta,
-        tool_calls,
         prioritize_tool_calls,
     })
 }
 
-pub(crate) fn apply_deferred_tool_calls<TDelta>(
-    prelude: OpenAiLikeChunkPrelude<'_, TDelta>,
+pub(crate) fn apply_deferred_tool_calls(
+    prelude: OpenAiLikeChunkPrelude<'_>,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
     current_block: &mut Option<CurrentBlock>,
@@ -217,7 +244,7 @@ pub(crate) fn apply_deferred_tool_calls<TDelta>(
         return;
     }
 
-    if let Some(tool_call_deltas) = prelude.tool_calls {
+    if let Some(tool_call_deltas) = &prelude.delta.tool_calls {
         handle_tool_calls(tool_call_deltas, output, sender, current_block);
     }
 }

--- a/src/providers/zai.rs
+++ b/src/providers/zai.rs
@@ -1,25 +1,18 @@
-use serde::Deserialize;
 use serde_json::json;
 
 use super::openai_completions::OpenAICompletionsOptions;
-#[cfg(test)]
-use super::shared::finish_current_block;
 use super::shared::{
-    apply_deferred_tool_calls, convert_messages, convert_tools, handle_reasoning_delta,
-    handle_text_delta, initialize_output, map_stop_reason, prepare_openai_like_chunk,
-    push_stream_error, run_openai_like_stream_without_state, AssistantThinkingMode, CurrentBlock,
-    OpenAiLikeMessageOptions, OpenAiLikeRequest, OpenAiLikeStreamChunk, OpenAiLikeToolCallDelta,
-    ReasoningDelta, SystemPromptRole,
+    apply_deferred_tool_calls, convert_messages, convert_tools, extract_reasoning,
+    handle_reasoning_delta, handle_text_delta, map_stop_reason, prepare_openai_like_chunk,
+    run_openai_like_stream, spawn_openai_like_stream, AssistantThinkingMode, CurrentBlock,
+    OpenAiLikeMessageOptions, OpenAiLikeRequest, OpenAiLikeStreamChunk, SystemPromptRole,
 };
+#[cfg(test)]
+use super::shared::{finish_current_block, initialize_output, REASONING_CONTENT_SIGNATURE};
 use crate::types::{
-    Api, AssistantMessage, AssistantMessageEventStream, Context, EventStreamSender, Model,
-    StopReason, ZaiCompletions,
+    AssistantMessage, AssistantMessageEventStream, Context, EventStreamSender, Model, StopReason,
+    ZaiChatCompletionsOptions, ZaiCompletions,
 };
-
-const STREAM_INCLUDE_USAGE_FIELD: &str = "include_usage";
-const REASONING_CONTENT_SIGNATURE: &str = "reasoning_content";
-const REASONING_SIGNATURE: &str = "reasoning";
-const REASONING_TEXT_SIGNATURE: &str = "reasoning_text";
 
 /// Stream completions from z.ai chat/completions API.
 pub fn stream_zai_completions(
@@ -27,37 +20,17 @@ pub fn stream_zai_completions(
     context: &Context,
     options: OpenAICompletionsOptions,
 ) -> AssistantMessageEventStream {
-    let (stream, sender) = AssistantMessageEventStream::new();
-
-    let model = model.clone();
-    let context = context.clone();
-
-    tokio::spawn(async move {
-        run_stream(model, context, options, sender).await;
-    });
-
-    stream
+    spawn_openai_like_stream(
+        model,
+        context,
+        options,
+        |model, context, options, output, sender| {
+            Box::pin(run_stream(model, context, options, output, sender))
+        },
+    )
 }
 
 async fn run_stream(
-    model: Model<ZaiCompletions>,
-    context: Context,
-    options: OpenAICompletionsOptions,
-    mut sender: EventStreamSender,
-) {
-    let mut output = initialize_output(
-        Api::ZaiCompletions,
-        model.provider.clone(),
-        model.id.clone(),
-    );
-
-    if let Err(error) = run_stream_inner(&model, &context, &options, &mut output, &mut sender).await
-    {
-        push_stream_error(&mut output, &mut sender, error);
-    }
-}
-
-async fn run_stream_inner(
     model: &Model<ZaiCompletions>,
     context: &Context,
     options: &OpenAICompletionsOptions,
@@ -65,21 +38,15 @@ async fn run_stream_inner(
     sender: &mut EventStreamSender,
 ) -> Result<(), crate::Error> {
     let params = build_params(model, context, options);
-    let request = OpenAiLikeRequest::new(
-        &model.provider,
-        &model.base_url,
-        &options.api_key,
-        model.headers.as_ref(),
-        options.headers.as_ref(),
-        &params,
-    );
 
-    run_openai_like_stream_without_state::<StreamChunk, _>(
-        request,
+    run_openai_like_stream(
+        OpenAiLikeRequest::new(model, options, &params),
         output,
         sender,
         |chunk, output, sender, current_block| {
-            process_chunk(&chunk, output, sender, current_block);
+            if let Some(chunk) = chunk {
+                process_chunk(&chunk, output, sender, current_block);
+            }
         },
     )
     .await
@@ -104,56 +71,48 @@ fn build_params(
     let mut params = json!({
         "model": model.id,
         "stream": true,
+        "stream_options": { "include_usage": true },
         "messages": convert_messages(model, context, &message_options),
     });
 
-    params["stream_options"] = json!({ STREAM_INCLUDE_USAGE_FIELD: true });
+    let zai_options = options.zai.as_ref();
 
-    add_max_tokens(&mut params, options);
-    add_temperature(&mut params, options);
-    add_tools(&mut params, context);
-    add_tool_choice(&mut params, options);
-    add_zai_optional_fields(&mut params, options);
-    add_default_reasoning(&mut params, model, options);
+    if let Some(max_tokens) = zai_options
+        .and_then(|zai_options| zai_options.max_tokens)
+        .or(options.max_tokens)
+    {
+        params["max_tokens"] = json!(max_tokens);
+    }
+
+    if let Some(temperature) = options.temperature {
+        params["temperature"] = json!(temperature);
+    }
+
+    if let Some(tools) = &context.tools {
+        params["tools"] = convert_tools(tools);
+    }
+
+    if let Some(tool_choice) = &options.tool_choice {
+        params["tool_choice"] = json!(tool_choice);
+    }
+
+    if let Some(zai_options) = zai_options {
+        add_zai_optional_fields(&mut params, zai_options);
+    }
+
+    let has_explicit_thinking =
+        zai_options.is_some_and(|zai_options| zai_options.thinking.is_some());
+    if model.reasoning && !has_explicit_thinking {
+        params["thinking"] = json!({ "type": "enabled" });
+    }
 
     params
 }
 
-fn add_max_tokens(params: &mut serde_json::Value, options: &OpenAICompletionsOptions) {
-    let max_tokens = options
-        .zai
-        .as_ref()
-        .and_then(|zai_options| zai_options.max_tokens)
-        .or(options.max_tokens);
-
-    if let Some(value) = max_tokens {
-        params["max_tokens"] = json!(value);
-    }
-}
-
-fn add_temperature(params: &mut serde_json::Value, options: &OpenAICompletionsOptions) {
-    if let Some(temperature) = options.temperature {
-        params["temperature"] = json!(temperature);
-    }
-}
-
-fn add_tools(params: &mut serde_json::Value, context: &Context) {
-    if let Some(tools) = &context.tools {
-        params["tools"] = convert_tools(tools);
-    }
-}
-
-fn add_tool_choice(params: &mut serde_json::Value, options: &OpenAICompletionsOptions) {
-    if let Some(tool_choice) = &options.tool_choice {
-        params["tool_choice"] = json!(tool_choice);
-    }
-}
-
-fn add_zai_optional_fields(params: &mut serde_json::Value, options: &OpenAICompletionsOptions) {
-    let Some(zai_options) = options.zai.as_ref() else {
-        return;
-    };
-
+fn add_zai_optional_fields(
+    params: &mut serde_json::Value,
+    zai_options: &ZaiChatCompletionsOptions,
+) {
     if let Some(do_sample) = zai_options.do_sample {
         params["do_sample"] = json!(do_sample);
     }
@@ -187,75 +146,27 @@ fn add_zai_optional_fields(params: &mut serde_json::Value, options: &OpenAICompl
     }
 }
 
-fn add_default_reasoning(
-    params: &mut serde_json::Value,
-    model: &Model<ZaiCompletions>,
-    options: &OpenAICompletionsOptions,
-) {
-    let has_explicit_thinking = options
-        .zai
-        .as_ref()
-        .and_then(|zai_options| zai_options.thinking.as_ref())
-        .is_some();
-
-    if model.reasoning && !has_explicit_thinking {
-        params["thinking"] = json!({ "type": "enabled" });
-    }
-}
-
 fn process_chunk(
-    chunk: &StreamChunk,
+    chunk: &OpenAiLikeStreamChunk,
     output: &mut AssistantMessage,
     sender: &mut EventStreamSender,
     current_block: &mut Option<CurrentBlock>,
 ) {
-    let Some(prelude) = prepare_openai_like_chunk(
-        chunk,
-        output,
-        sender,
-        current_block,
-        map_zai_stop_reason,
-        delta_tool_calls,
-    ) else {
+    let Some(prelude) =
+        prepare_openai_like_chunk(chunk, output, sender, current_block, map_zai_stop_reason)
+    else {
         return;
     };
 
-    let delta = prelude.delta;
-
-    if let Some(content) = delta.content.as_deref() {
+    if let Some(content) = prelude.delta.content.as_deref() {
         handle_text_delta(content, output, sender, current_block);
     }
 
-    if let Some(reasoning) = extract_reasoning(delta) {
+    if let Some(reasoning) = extract_reasoning(prelude.delta) {
         handle_reasoning_delta(reasoning, output, sender, current_block);
     }
 
     apply_deferred_tool_calls(prelude, output, sender, current_block);
-}
-
-fn delta_tool_calls(delta: &StreamDelta) -> Option<&[OpenAiLikeToolCallDelta]> {
-    delta.tool_calls.as_deref()
-}
-
-fn extract_reasoning(delta: &StreamDelta) -> Option<ReasoningDelta<'_>> {
-    if let Some(text) = delta.reasoning_content.as_deref() {
-        return Some(ReasoningDelta {
-            text,
-            signature: REASONING_CONTENT_SIGNATURE,
-        });
-    }
-
-    if let Some(text) = delta.reasoning.as_deref() {
-        return Some(ReasoningDelta {
-            text,
-            signature: REASONING_SIGNATURE,
-        });
-    }
-
-    delta.reasoning_text.as_deref().map(|text| ReasoningDelta {
-        text,
-        signature: REASONING_TEXT_SIGNATURE,
-    })
 }
 
 fn map_zai_stop_reason(reason: &str) -> StopReason {
@@ -265,28 +176,17 @@ fn map_zai_stop_reason(reason: &str) -> StopReason {
     }
 }
 
-type StreamChunk = OpenAiLikeStreamChunk<StreamDelta>;
-
-#[derive(Debug, Deserialize)]
-struct StreamDelta {
-    content: Option<String>,
-    reasoning_content: Option<String>,
-    reasoning: Option<String>,
-    reasoning_text: Option<String>,
-    tool_calls: Option<Vec<OpenAiLikeToolCallDelta>>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_helpers::{
-        assert_final_message_shape, build_final_message_shape_chunks,
-        populated_zai_chat_completions_options, populated_zai_chat_completions_options_json,
-        ExpectedFinalMessageShape,
+        assert_final_message_shape, assert_multiply_tool_call, build_final_message_shape_chunks,
+        concise_context, make_test_model, populated_zai_chat_completions_options,
+        populated_zai_chat_completions_options_json, tool_call_continuation_chunk,
+        tool_call_start_chunk, ExpectedFinalMessageShape,
     };
     use crate::types::{
-        AssistantMessageEvent, Content, InputType, KnownProvider, Message, ModelCost, Provider,
-        Usage, UserContent, UserMessage, ZaiChatCompletionsOptions,
+        Api, AssistantMessageEvent, Content, KnownProvider, Message, Provider, Usage,
     };
     use futures::executor::block_on;
     use futures::StreamExt;
@@ -294,56 +194,24 @@ mod tests {
     const TEST_BASE_URL: &str = "https://api.z.ai/api/paas/v4/chat/completions";
 
     fn make_model(reasoning: bool) -> Model<ZaiCompletions> {
-        Model {
-            id: "glm-4.7".to_string(),
-            name: "GLM 4.7".to_string(),
-            api: ZaiCompletions,
-            provider: Provider::Known(KnownProvider::Zai),
-            base_url: TEST_BASE_URL.to_string(),
+        make_test_model(
+            ZaiCompletions,
+            KnownProvider::Zai,
+            "glm-4.7",
+            TEST_BASE_URL,
             reasoning,
-            input: vec![InputType::Text],
-            cost: ModelCost {
-                input: 0.0,
-                output: 0.0,
-                cache_read: 0.0,
-                cache_write: 0.0,
-            },
-            context_window: 200_000,
-            max_tokens: 128_000,
-            headers: None,
-            compat: None,
-        }
-    }
-
-    fn make_context() -> Context {
-        Context {
-            system_prompt: Some("You are concise".to_string()),
-            messages: vec![Message::User(UserMessage {
-                content: UserContent::Text("Hello".to_string()),
-                timestamp: 0,
-            })],
-            tools: None,
-        }
-    }
-
-    fn make_output_message() -> AssistantMessage {
-        AssistantMessage {
-            content: vec![],
-            api: Api::ZaiCompletions,
-            provider: Provider::Known(KnownProvider::Zai),
-            model: "glm-4.7".to_string(),
-            usage: Usage::default(),
-            stop_reason: StopReason::Stop,
-            error_message: None,
-            timestamp: 0,
-        }
+        )
     }
 
     fn process_chunks_for_test(
-        chunks: Vec<StreamChunk>,
+        chunks: Vec<OpenAiLikeStreamChunk>,
     ) -> (Vec<AssistantMessageEvent>, AssistantMessage) {
         let (mut stream, mut sender) = AssistantMessageEventStream::new();
-        let mut output = make_output_message();
+        let mut output = initialize_output(
+            Api::ZaiCompletions,
+            Provider::Known(KnownProvider::Zai),
+            "glm-4.7".to_string(),
+        );
         let mut current_block = None;
 
         for chunk in chunks {
@@ -355,74 +223,6 @@ mod tests {
 
         let events = block_on(async move { stream.by_ref().collect::<Vec<_>>().await });
         (events, output)
-    }
-
-    fn tool_call_start_chunk(call_id: &str) -> StreamChunk {
-        serde_json::from_value(json!({
-            "choices": [{
-                "delta": {
-                    "tool_calls": [{
-                        "id": call_id,
-                        "type": "function",
-                        "function": {
-                            "name": "multiply",
-                            "arguments": "{\"a\": 15, \"b\": "
-                        },
-                        "index": 0
-                    }]
-                }
-            }]
-        }))
-        .expect("valid first tool-call chunk")
-    }
-
-    fn tool_call_continuation_with_content_chunk(content: &str) -> StreamChunk {
-        serde_json::from_value(json!({
-            "choices": [{
-                "finish_reason": "tool_calls",
-                "delta": {
-                    "content": content,
-                    "tool_calls": [{
-                        "type": "function",
-                        "function": {
-                            "arguments": "3}"
-                        },
-                        "index": 0
-                    }]
-                }
-            }]
-        }))
-        .expect("valid interleaved continuation chunk")
-    }
-
-    fn tool_call_continuation_with_reasoning_chunk(reasoning_text: &str) -> StreamChunk {
-        serde_json::from_value(json!({
-            "choices": [{
-                "finish_reason": "tool_calls",
-                "delta": {
-                    "reasoning_content": reasoning_text,
-                    "tool_calls": [{
-                        "type": "function",
-                        "function": {
-                            "arguments": "3}"
-                        },
-                        "index": 0
-                    }]
-                }
-            }]
-        }))
-        .expect("valid interleaved reasoning continuation chunk")
-    }
-
-    fn assert_multiply_tool_call(content: &Content, expected_call_id: &str) {
-        match content {
-            Content::ToolCall { inner } => {
-                assert_eq!(inner.id.as_str(), expected_call_id);
-                assert_eq!(inner.name, "multiply");
-                assert_eq!(inner.arguments, json!({"a": 15, "b": 3}));
-            }
-            _ => panic!("expected tool call content"),
-        }
     }
 
     #[test]
@@ -457,7 +257,7 @@ mod tests {
         let params = build_params(&model, &context, &options);
 
         assert_eq!(params["stream"], true);
-        assert_eq!(params["stream_options"][STREAM_INCLUDE_USAGE_FIELD], true);
+        assert_eq!(params["stream_options"]["include_usage"], true);
         assert_eq!(params["max_tokens"], 1024);
         assert!(params.get("max_completion_tokens").is_none());
         assert_eq!(params["messages"][0]["content"], "final answer");
@@ -468,7 +268,7 @@ mod tests {
     #[test]
     fn build_params_serializes_optional_zai_fields_and_explicit_thinking() {
         let model = make_model(true);
-        let context = make_context();
+        let context = concise_context();
         let expected = populated_zai_chat_completions_options_json();
         let options = OpenAICompletionsOptions {
             zai: Some(populated_zai_chat_completions_options()),
@@ -497,7 +297,7 @@ mod tests {
 
     #[test]
     fn process_chunk_maps_usage_and_reasoning() {
-        let chunk: StreamChunk = serde_json::from_value(json!({
+        let chunk: OpenAiLikeStreamChunk = serde_json::from_value(json!({
             "choices": [{
                 "finish_reason": "stop",
                 "delta": {
@@ -540,7 +340,7 @@ mod tests {
     fn process_chunk_prioritizes_tool_call_continuations_before_content() {
         let (_events, output) = process_chunks_for_test(vec![
             tool_call_start_chunk("call_function_1"),
-            tool_call_continuation_with_content_chunk("tail"),
+            tool_call_continuation_chunk(json!({ "content": "tail" })),
         ]);
 
         assert_eq!(output.stop_reason, StopReason::ToolUse);
@@ -557,7 +357,7 @@ mod tests {
     fn process_chunk_prioritizes_tool_call_continuations_before_reasoning() {
         let (_events, output) = process_chunks_for_test(vec![
             tool_call_start_chunk("call_function_2"),
-            tool_call_continuation_with_reasoning_chunk("next step"),
+            tool_call_continuation_chunk(json!({ "reasoning_content": "next step" })),
         ]);
 
         assert_eq!(output.stop_reason, StopReason::ToolUse);
@@ -578,7 +378,7 @@ mod tests {
 
     #[test]
     fn stream_zai_completions_final_message_shape() {
-        let chunks = build_final_message_shape_chunks::<StreamChunk>(json!({
+        let chunks = build_final_message_shape_chunks(json!({
             "reasoning_content": "reason"
         }));
         let (_events, output) = process_chunks_for_test(chunks);

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -1,8 +1,9 @@
+use crate::providers::shared::OpenAiLikeStreamChunk;
 use crate::types::{
-    Api, AssistantMessage, Provider, StopReason, ZaiChatCompletionsOptions, ZaiResponseFormat,
-    ZaiResponseFormatType, ZaiThinking, ZaiThinkingType,
+    Api, ApiType, AssistantMessage, Content, Context, InputType, KnownProvider, Message, Model,
+    ModelCost, Provider, StopReason, UserContent, UserMessage, ZaiChatCompletionsOptions,
+    ZaiResponseFormat, ZaiResponseFormatType, ZaiThinking, ZaiThinkingType,
 };
-use serde::de::DeserializeOwned;
 use serde_json::json;
 
 pub(crate) struct ExpectedFinalMessageShape<'a> {
@@ -55,12 +56,112 @@ pub(crate) fn populated_zai_chat_completions_options_json() -> serde_json::Value
     })
 }
 
-pub(crate) fn build_final_message_shape_chunks<TChunk>(
+/// A model with sensible defaults for exercising provider streaming code.
+pub(crate) fn make_test_model<TApi: ApiType>(
+    api: TApi,
+    provider: KnownProvider,
+    id: &str,
+    base_url: &str,
+    reasoning: bool,
+) -> Model<TApi> {
+    Model {
+        id: id.to_string(),
+        name: id.to_string(),
+        api,
+        provider: Provider::Known(provider),
+        base_url: base_url.to_string(),
+        reasoning,
+        input: vec![InputType::Text],
+        cost: ModelCost {
+            input: 0.0,
+            output: 0.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        },
+        context_window: 128_000,
+        max_tokens: 4_096,
+        headers: None,
+        compat: None,
+    }
+}
+
+pub(crate) fn concise_context() -> Context {
+    Context {
+        system_prompt: Some("You are concise".to_string()),
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text("Hello".to_string()),
+            timestamp: 0,
+        })],
+        tools: None,
+    }
+}
+
+/// First chunk of a streamed `multiply(a: 15, b: 3)` tool call.
+pub(crate) fn tool_call_start_chunk(call_id: &str) -> OpenAiLikeStreamChunk {
+    serde_json::from_value(json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "multiply",
+                        "arguments": "{\"a\": 15, \"b\": "
+                    },
+                    "index": 0
+                }]
+            }
+        }]
+    }))
+    .expect("valid first tool-call chunk")
+}
+
+/// Final chunk of the `multiply` tool call started by [`tool_call_start_chunk`],
+/// with `extra_delta_fields` (e.g. `content` or `reasoning_content`) merged
+/// into the delta to simulate interleaved output.
+pub(crate) fn tool_call_continuation_chunk(
+    extra_delta_fields: serde_json::Value,
+) -> OpenAiLikeStreamChunk {
+    let mut delta = json!({
+        "tool_calls": [{
+            "type": "function",
+            "function": {
+                "arguments": "3}"
+            },
+            "index": 0
+        }]
+    });
+
+    for (key, value) in extra_delta_fields
+        .as_object()
+        .expect("extra delta fields must be a JSON object")
+    {
+        delta[key] = value.clone();
+    }
+
+    serde_json::from_value(json!({
+        "choices": [{
+            "finish_reason": "tool_calls",
+            "delta": delta
+        }]
+    }))
+    .expect("valid tool-call continuation chunk")
+}
+
+pub(crate) fn assert_multiply_tool_call(content: &Content, expected_call_id: &str) {
+    match content {
+        Content::ToolCall { inner } => {
+            assert_eq!(inner.id.as_str(), expected_call_id);
+            assert_eq!(inner.name, "multiply");
+            assert_eq!(inner.arguments, json!({"a": 15, "b": 3}));
+        }
+        _ => panic!("expected tool call content"),
+    }
+}
+
+pub(crate) fn build_final_message_shape_chunks(
     reasoning_delta: serde_json::Value,
-) -> Vec<TChunk>
-where
-    TChunk: DeserializeOwned,
-{
+) -> Vec<OpenAiLikeStreamChunk> {
     vec![
         serde_json::from_value(json!({
             "choices": [{

--- a/tests/openai_like_streaming.rs
+++ b/tests/openai_like_streaming.rs
@@ -1,0 +1,137 @@
+//! End-to-end test of the OpenAI-like streaming pipeline over a real socket:
+//! request building, SSE parsing, chunk processing, and stream finalization.
+
+use alchemy_llm::types::{
+    AssistantMessageEvent, Content, InputType, KnownProvider, Model, ModelCost, OpenAICompletions,
+    Provider, StopReason, UserContent, UserMessage,
+};
+use alchemy_llm::{stream_openai_completions, OpenAICompletionsOptions};
+use futures::StreamExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const SSE_BODY: &str = "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"thinking hard\"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"hello \"}}]}\n\n\
+data: {\"choices\":[{\"delta\":{\"content\":\"world\"},\"finish_reason\":\"stop\"}]}\n\n\
+data: {\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3,\"total_tokens\":10}}\n\n\
+data: [DONE]\n\n";
+
+async fn spawn_sse_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let address = listener.local_addr().expect("local addr");
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept");
+
+        // Drain the request before responding.
+        let mut buffer = [0u8; 4096];
+        let _ = socket.read(&mut buffer).await;
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            SSE_BODY.len(),
+            SSE_BODY
+        );
+        socket.write_all(response.as_bytes()).await.expect("write");
+        socket.shutdown().await.ok();
+    });
+
+    format!("http://{address}/v1/chat/completions")
+}
+
+fn make_model(base_url: String) -> Model<OpenAICompletions> {
+    Model {
+        id: "test-model".to_string(),
+        name: "Test Model".to_string(),
+        api: OpenAICompletions,
+        provider: Provider::Known(KnownProvider::OpenAI),
+        base_url,
+        reasoning: false,
+        input: vec![InputType::Text],
+        cost: ModelCost {
+            input: 0.0,
+            output: 0.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        },
+        context_window: 128_000,
+        max_tokens: 4_096,
+        headers: None,
+        compat: None,
+    }
+}
+
+fn make_context() -> alchemy_llm::types::Context {
+    alchemy_llm::types::Context {
+        system_prompt: None,
+        messages: vec![alchemy_llm::types::Message::User(UserMessage {
+            content: UserContent::Text("Hi".to_string()),
+            timestamp: 0,
+        })],
+        tools: None,
+    }
+}
+
+#[tokio::test]
+async fn streams_reasoning_text_and_usage_end_to_end() {
+    let base_url = spawn_sse_server().await;
+    let model = make_model(base_url);
+
+    let stream = stream_openai_completions(
+        &model,
+        &make_context(),
+        OpenAICompletionsOptions {
+            api_key: Some("test-key".to_string()),
+            ..OpenAICompletionsOptions::default()
+        },
+    );
+
+    let events: Vec<AssistantMessageEvent> = stream.collect().await;
+
+    assert!(matches!(
+        events.first(),
+        Some(AssistantMessageEvent::Start { .. })
+    ));
+
+    let message = match events.last() {
+        Some(AssistantMessageEvent::Done { message, .. }) => message,
+        other => panic!("expected Done event, got {other:?}"),
+    };
+
+    assert_eq!(message.stop_reason, StopReason::Stop);
+    assert_eq!(message.usage.input, 7);
+    assert_eq!(message.usage.output, 3);
+    assert_eq!(message.usage.total_tokens, 10);
+
+    assert_eq!(message.content.len(), 2);
+    match &message.content[0] {
+        Content::Thinking { inner } => assert_eq!(inner.thinking, "thinking hard"),
+        other => panic!("expected thinking content, got {other:?}"),
+    }
+    match &message.content[1] {
+        Content::Text { inner } => assert_eq!(inner.text, "hello world"),
+        other => panic!("expected text content, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn missing_api_key_yields_error_event() {
+    let model = make_model("http://127.0.0.1:9/v1/chat/completions".to_string());
+
+    let stream =
+        stream_openai_completions(&model, &make_context(), OpenAICompletionsOptions::default());
+
+    let events: Vec<AssistantMessageEvent> = stream.collect().await;
+
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        AssistantMessageEvent::Error { error, .. } => {
+            assert_eq!(error.stop_reason, StopReason::Error);
+            assert!(error
+                .error_message
+                .as_deref()
+                .is_some_and(|message| message.contains("No API key")));
+        }
+        other => panic!("expected Error event, got {other:?}"),
+    }
+}


### PR DESCRIPTION
The three OpenAI-compatible providers (openai_completions, zai, minimax)
were heavy copy-paste of each other. Consolidate the duplication into
providers/shared and delete the redundant code (~400 net lines):

- One shared OpenAiLikeStreamDelta/StreamChunk type replaces the three
  identical per-provider StreamDelta structs, de-genericizing
  prepare_openai_like_chunk and the runtime along the way.
- Shared extract_reasoning replaces the identical copies in zai and
  openai_completions (and minimax's hand-rolled fallback loop). It skips
  empty strings so minimax's field-fallback behavior is preserved.
- New spawn_openai_like_stream helper owns the stream/spawn/init/error
  boilerplate that every provider repeated in stream_x + run_stream.
- run_openai_like_stream now signals end-of-stream with a final None
  event instead of threading a TState generic plus a before_finish hook,
  removing the run_openai_like_stream_without_state wrapper.
- process_sse_stream now delegates to process_sse_stream_with_event
  instead of duplicating the SSE parse loop; [DONE] handling is unified.
- openai_completions uses the shared prepare/apply chunk path instead of
  hand-rolling it, gaining the same tool-call-continuation prioritization
  the other providers already had; its odd From<(Self, &Compat)> impl is
  now a plain with_overrides method.
- minimax's duplicated feed/flush think-fragment handling collapses into
  emit_think_fragments; single-use string constants inlined.
- Duplicated test scaffolding (model/context builders, tool-call chunk
  builders, multiply-tool-call assertion) moves to test_helpers.

Add an end-to-end integration test that drives stream_openai_completions
against a local SSE server, covering the spawn helper, request building,
SSE parsing, and finalization path that unit tests didn't exercise.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K6P2HA4Fn2mjH4nKmH5C1o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming responses across supported AI providers, including more consistent reasoning, text, tool-call, and usage handling.
  * Added support for reasoning content delivered through multiple response formats, including think-tagged text.
  * Streaming now reports final token usage more reliably.

* **Bug Fixes**
  * Improved handling of tool-call continuations and empty reasoning fields.
  * Added clearer error reporting when required credentials are missing.

* **Tests**
  * Added end-to-end coverage for streaming responses, reasoning output, usage reporting, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->